### PR TITLE
FormatGuesser

### DIFF
--- a/RDSSurveyor/src/eu/jacquet80/rds/RDSSurveyor.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/RDSSurveyor.java
@@ -239,6 +239,7 @@ public class RDSSurveyor {
 					System.out.println("Arguments:");
 					System.out.println("  -inaudio                 Use sound card audio as input");
 					System.out.println("  -inbinfile <file>        Use the given binary file as input");
+					System.out.println("  -insyncbinfile <file>    Use the given synchronized binary file as input");
 					System.out.println("  -inbinstrfile <file>     Use the given binary string file as input");
 					System.out.println("  -inaudiofile <file>      Use the given audio file as input");
 					System.out.println("  -ingrouphexfile <file>   Use the given group-level file as input");

--- a/RDSSurveyor/src/eu/jacquet80/rds/RDSSurveyor.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/RDSSurveyor.java
@@ -47,6 +47,7 @@ import eu.jacquet80.rds.input.AudioFileBitReader;
 import eu.jacquet80.rds.input.BinStringFileBitReader;
 import eu.jacquet80.rds.input.BinaryFileBitReader;
 import eu.jacquet80.rds.input.BitReader;
+import eu.jacquet80.rds.input.FileFormatGuesser;
 import eu.jacquet80.rds.input.GroupReader;
 import eu.jacquet80.rds.input.HexFileGroupReader;
 import eu.jacquet80.rds.input.LiveAudioBitReader;
@@ -170,6 +171,8 @@ public class RDSSurveyor {
 					reader = new BitStreamSynchronizer(console, new BinStringFileBitReader(new File(getParam("inbinstrfile", args, ++i))));
 				} else if("-ingrouphexfile".equals(args[i])) {
 					reader  = new HexFileGroupReader(new File(getParam("ingrouphexfile", args, ++i)));
+				} else if("-infile".equals(args[i])) {
+					reader = FileFormatGuesser.createReader(new File(getParam("infile", args, ++i)));
 				} else if("-intcp".equals(args[i])) {
 					reader = new TCPTunerGroupReader(getParam("intcp", args, ++i), 8750);
 				} else if("-inusbkey".equals(args[i])) {
@@ -239,6 +242,7 @@ public class RDSSurveyor {
 					System.out.println("  -inbinstrfile <file>     Use the given binary string file as input");
 					System.out.println("  -inaudiofile <file>      Use the given audio file as input");
 					System.out.println("  -ingrouphexfile <file>   Use the given group-level file as input");
+					System.out.println("  -infile <file>           Use the given file as input (autodetect format)");
 					System.out.println("  -inv4l <device>          Reads from Video4Linux device, e.g. /dev/radio");
 					System.out.println("  -intuner <driver>        Reads from a native tuner, specify driver (.so, .dll, .dylib)");
 					System.out.println("  -invert / -noinvert      Force bit inversion (default: auto-detect");

--- a/RDSSurveyor/src/eu/jacquet80/rds/core/BitStreamBreakOut.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/core/BitStreamBreakOut.java
@@ -33,7 +33,7 @@ import eu.jacquet80.rds.input.BinStringFileBitReader;
 import eu.jacquet80.rds.input.BitReader;
 
 public class BitStreamBreakOut {
-	public static void main(String[] args) throws FileNotFoundException {
+	public static void main(String[] args) throws IOException {
 		BitReader reader = new BinStringFileBitReader(new File(args[0]));
 		int block = 0;
 		StringBuffer strBlock = new StringBuffer();

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/BinStringFileBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/BinStringFileBitReader.java
@@ -36,14 +36,14 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 
 public class BinStringFileBitReader extends BitReader {
-	private final BufferedReader isr;
+	private final InputStream isr;
 	
-	public BinStringFileBitReader(BufferedReader isr) {
+	public BinStringFileBitReader(InputStream isr) {
 		this.isr = isr;
 	}
 	
 	public BinStringFileBitReader(File f) throws IOException {
-		isr = new BufferedReader(new InputStreamReader(new FileInputStream(f), "ASCII"));
+		isr = new FileInputStream(f);
 	}
 	
 	public boolean getBit() throws IOException {

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/BinStringFileBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/BinStringFileBitReader.java
@@ -25,18 +25,25 @@
 
 package eu.jacquet80.rds.input;
 
+import java.io.BufferedReader;
 import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 
 public class BinStringFileBitReader extends BitReader {
-	private final InputStream isr;
+	private final BufferedReader isr;
 	
-	public BinStringFileBitReader(File f) throws FileNotFoundException {
-		isr = new FileInputStream(f);
+	public BinStringFileBitReader(BufferedReader isr) {
+		this.isr = isr;
+	}
+	
+	public BinStringFileBitReader(File f) throws IOException {
+		isr = new BufferedReader(new InputStreamReader(new FileInputStream(f), "ASCII"));
 	}
 	
 	public boolean getBit() throws IOException {

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/FileFormatGuesser.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/FileFormatGuesser.java
@@ -36,18 +36,22 @@ public class FileFormatGuesser {
 				guessString.startsWith("<recorder=\"RDS Spy\"") ||
 				HEXGROUP_PATTERN.matcher(guessString).matches()) {
 			// grouphexfile
+			System.out.println("Detected a group-level file.");
 			bis.reset();
 			return new HexFileGroupReader(new BufferedReader(new InputStreamReader(bis)));
 		} else if (BINSTR_PATTERN.matcher(guessString).matches()) {
 			// binstrfile
+			System.out.println("Detected a binary string file.");
 			bis.reset();
 			return new BitStreamSynchronizer(System.out, new BinStringFileBitReader(bis));
 		} else if ((guessString.length() >= 2) && (guessString.codePointAt(0) == 0xfffd) && (guessString.codePointAt(1) == 0x6)) {
 			// syncbinfile
+			System.out.println("Detected a synchronized binary file.");
 			bis.reset();
 			return new BitStreamSynchronizer(System.out, new SyncBinaryFileBitReader(bis));
 		} else {
 			// binfile
+			System.out.println("Detected a binary file.");
 			bis.reset();
 			return new BitStreamSynchronizer(System.out, new BinaryFileBitReader(bis));
 		}

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/FileFormatGuesser.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/FileFormatGuesser.java
@@ -15,6 +15,8 @@ public class FileFormatGuesser {
 	private static final int GUESS_BUFFER_SIZE = 40;
 	private static final Pattern HEXGROUP_PATTERN = 
 			Pattern.compile("([0-9A-F]{4}|----)\\s+([0-9A-F]{4}|----)\\s+([0-9A-F]{4}|----)\\s+([0-9A-F]{4}|----)");
+	private static final Pattern BINSTR_PATTERN =
+			Pattern.compile("[01]{40}");
 	
 	private static GroupReader createReader(InputStream is) throws IOException {
 		char[] guessBuffer = new char[GUESS_BUFFER_SIZE];
@@ -33,6 +35,9 @@ public class FileFormatGuesser {
 				HEXGROUP_PATTERN.matcher(guessString).matches()) {
 			br.reset();
 			return new HexFileGroupReader(br);
+		} else if (BINSTR_PATTERN.matcher(guessString).matches()) {
+			br.reset();
+			return new BitStreamSynchronizer(System.out, new BinStringFileBitReader(br));
 		} else {
 			// binary file
 			// do not call br.close()!

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/SyncBinaryFileBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/SyncBinaryFileBitReader.java
@@ -38,8 +38,8 @@ public class SyncBinaryFileBitReader extends BitReader {
 	private int octPtr;
 	private int bytePtr;
 	
-	public SyncBinaryFileBitReader(File f) throws FileNotFoundException {
-		isr = new FileInputStream(f);
+	public SyncBinaryFileBitReader(InputStream isr) throws FileNotFoundException {
+		this.isr = isr;
 		try {
 			// read two bytes at the start
 			isr.read(); isr.read(); 
@@ -49,6 +49,10 @@ public class SyncBinaryFileBitReader extends BitReader {
 		oct = 0;
 		octPtr = 0;
 		bytePtr = 3;
+	}
+	
+	public SyncBinaryFileBitReader(File f) throws FileNotFoundException {
+		this(new FileInputStream(f));
 	}
 	
 	


### PR DESCRIPTION
Now recognizes all supported file formats other than audiofile. New -infile argument to provide format guesser functionality from the command line. Also fixes a bug that would cause truncation of binfiles identified through FormatGuesser,