### PR TITLE
make audio work with ADS RDX-155 Instant FM Music on Linux

### DIFF
--- a/RDSSurveyor/src/eu/jacquet80/rds/input/NativeTunerGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/NativeTunerGroupReader.java
@@ -192,7 +192,8 @@ public class NativeTunerGroupReader extends TunerGroupReader {
 	private final static String[] okNames = {
 		"FM Radio",
 		"Radio",
-		"ADS"
+		"ADS",
+		"Music"
 	};
 
 	


### PR DESCRIPTION
As it turns out, #2cb6017 doesn’t fix things for me but showed me the way.

On my Linux machine the device gets identified as  vendor `'ALSA (http://www.alsa-project.org)'`, device `'Music [plughw:1,0]'`, which gets truncated to `ALSA/Music`. This fix adds `Music` to the list of accepted names. Currently listening to the radio this way :-)

On the long run, it might make sense to do slightly more sophisticated filtering, especially on ALSA devices.