### PR TITLE
RTL2832U Fixes and Enhancements

### DIFF
--- a/JNIBackends/rtl2832u/Makefile.linux
+++ b/JNIBackends/rtl2832u/Makefile.linux
@@ -4,4 +4,4 @@ LINKFLAGS=`pkg-config librtlsdr --libs` -lrt -lpthread
 all: rtl_plugin
 
 rtl_plugin: eu_jacquet80_rds_input_NativeTunerGroupReader.h rtl_plugin.c convenience/convenience.c
-	gcc -shared -o rtl.so rtl_plugin.c convenience/convenience.c -I /usr/lib/jvm/default-java/include -I /usr/lib/jvm/default-java/include/linux $(FLAGS) $(LINKFLAGS)
+	gcc -shared -o rtl.so rtl_plugin.c convenience/convenience.c kissfft/kiss_fft.c kissfft/kiss_fftr.c -I /usr/lib/jvm/default-java/include -I /usr/lib/jvm/default-java/include/linux $(FLAGS) $(LINKFLAGS)

--- a/JNIBackends/rtl2832u/Makefile.linux
+++ b/JNIBackends/rtl2832u/Makefile.linux
@@ -4,4 +4,4 @@ LINKFLAGS=`pkg-config librtlsdr --libs` -lrt -lpthread
 all: rtl_plugin
 
 rtl_plugin: eu_jacquet80_rds_input_NativeTunerGroupReader.h rtl_plugin.c convenience/convenience.c
-	gcc -shared -o rtl.so rtl_plugin.c convenience/convenience.c -I /usr/lib/jvm/default-java/include $(FLAGS) $(LINKFLAGS)
+	gcc -shared -o rtl.so rtl_plugin.c convenience/convenience.c -I /usr/lib/jvm/default-java/include -I /usr/lib/jvm/default-java/include/linux $(FLAGS) $(LINKFLAGS)

--- a/JNIBackends/rtl2832u/Makefile.mac
+++ b/JNIBackends/rtl2832u/Makefile.mac
@@ -4,5 +4,5 @@ LINKFLAGS=`pkg-config librtlsdr --libs` -framework IOKit -framework CoreFoundati
 all: rtl_plugin
 
 rtl_plugin: eu_jacquet80_rds_input_NativeTunerGroupReader.h rtl_plugin.c convenience/convenience.c
-	gcc -shared -o rtl.dylib rtl_plugin.c convenience/convenience.c -I /System/Library/Frameworks/JavaVM.framework/Headers $(FLAGS) $(LINKFLAGS)
+	gcc -shared -o rtl.dylib rtl_plugin.c convenience/convenience.c kissfft/kiss_fft.c kissfft/kiss_fftr.c -I /System/Library/Frameworks/JavaVM.framework/Headers $(FLAGS) $(LINKFLAGS)
 	

--- a/JNIBackends/rtl2832u/Makefile.windows
+++ b/JNIBackends/rtl2832u/Makefile.windows
@@ -6,7 +6,7 @@ JAVADIR=C:/Program\ Files/Java/jdk1.7.0_07
 all: rtl_plugin
 
 rtl_plugin: eu_jacquet80_rds_input_NativeTunerGroupReader.h rtl_plugin.c convenience/convenience.c dllinfo
-	gcc -D_JNI_IMPLEMENTATION_ -Wl,--kill-at -static -shared -o rtl.dll dllinfo.o rtl_plugin.c convenience/convenience.c -I $(JAVADIR)/include -I $(JAVADIR)/include/win32 -Wl,--subsystem,windows -s $(FLAGS) $(LINKFLAGS)
+	gcc -D_JNI_IMPLEMENTATION_ -Wl,--kill-at -static -shared -o rtl.dll dllinfo.o rtl_plugin.c convenience/convenience.c kissfft/kiss_fft.c kissfft/kiss_fftr.c -I $(JAVADIR)/include -I $(JAVADIR)/include/win32 -Wl,--subsystem,windows -s $(FLAGS) $(LINKFLAGS)
 
 dllinfo: dllinfo.rc
 	windres -i dllinfo.rc -o dllinfo.o

--- a/JNIBackends/rtl2832u/kissfft/_kiss_fft_guts.h
+++ b/JNIBackends/rtl2832u/kissfft/_kiss_fft_guts.h
@@ -1,0 +1,164 @@
+/*
+Copyright (c) 2003-2010, Mark Borgerding
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the author nor the names of any contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* kiss_fft.h
+   defines kiss_fft_scalar as either short or a float type
+   and defines
+   typedef struct { kiss_fft_scalar r; kiss_fft_scalar i; }kiss_fft_cpx; */
+#include "kiss_fft.h"
+#include <limits.h>
+
+#define MAXFACTORS 32
+/* e.g. an fft of length 128 has 4 factors 
+ as far as kissfft is concerned
+ 4*4*4*2
+ */
+
+struct kiss_fft_state{
+    int nfft;
+    int inverse;
+    int factors[2*MAXFACTORS];
+    kiss_fft_cpx twiddles[1];
+};
+
+/*
+  Explanation of macros dealing with complex math:
+
+   C_MUL(m,a,b)         : m = a*b
+   C_FIXDIV( c , div )  : if a fixed point impl., c /= div. noop otherwise
+   C_SUB( res, a,b)     : res = a - b
+   C_SUBFROM( res , a)  : res -= a
+   C_ADDTO( res , a)    : res += a
+ * */
+#ifdef FIXED_POINT
+#if (FIXED_POINT==32)
+# define FRACBITS 31
+# define SAMPPROD int64_t
+#define SAMP_MAX 2147483647
+#else
+# define FRACBITS 15
+# define SAMPPROD int32_t 
+#define SAMP_MAX 32767
+#endif
+
+#define SAMP_MIN -SAMP_MAX
+
+#if defined(CHECK_OVERFLOW)
+#  define CHECK_OVERFLOW_OP(a,op,b)  \
+	if ( (SAMPPROD)(a) op (SAMPPROD)(b) > SAMP_MAX || (SAMPPROD)(a) op (SAMPPROD)(b) < SAMP_MIN ) { \
+		fprintf(stderr,"WARNING:overflow @ " __FILE__ "(%d): (%d " #op" %d) = %ld\n",__LINE__,(a),(b),(SAMPPROD)(a) op (SAMPPROD)(b) );  }
+#endif
+
+
+#   define smul(a,b) ( (SAMPPROD)(a)*(b) )
+#   define sround( x )  (kiss_fft_scalar)( ( (x) + (1<<(FRACBITS-1)) ) >> FRACBITS )
+
+#   define S_MUL(a,b) sround( smul(a,b) )
+
+#   define C_MUL(m,a,b) \
+      do{ (m).r = sround( smul((a).r,(b).r) - smul((a).i,(b).i) ); \
+          (m).i = sround( smul((a).r,(b).i) + smul((a).i,(b).r) ); }while(0)
+
+#   define DIVSCALAR(x,k) \
+	(x) = sround( smul(  x, SAMP_MAX/k ) )
+
+#   define C_FIXDIV(c,div) \
+	do {    DIVSCALAR( (c).r , div);  \
+		DIVSCALAR( (c).i  , div); }while (0)
+
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r =  sround( smul( (c).r , s ) ) ;\
+        (c).i =  sround( smul( (c).i , s ) ) ; }while(0)
+
+#else  /* not FIXED_POINT*/
+
+#   define S_MUL(a,b) ( (a)*(b) )
+#define C_MUL(m,a,b) \
+    do{ (m).r = (a).r*(b).r - (a).i*(b).i;\
+        (m).i = (a).r*(b).i + (a).i*(b).r; }while(0)
+#   define C_FIXDIV(c,div) /* NOOP */
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r *= (s);\
+        (c).i *= (s); }while(0)
+#endif
+
+#ifndef CHECK_OVERFLOW_OP
+#  define CHECK_OVERFLOW_OP(a,op,b) /* noop */
+#endif
+
+#define  C_ADD( res, a,b)\
+    do { \
+	    CHECK_OVERFLOW_OP((a).r,+,(b).r)\
+	    CHECK_OVERFLOW_OP((a).i,+,(b).i)\
+	    (res).r=(a).r+(b).r;  (res).i=(a).i+(b).i; \
+    }while(0)
+#define  C_SUB( res, a,b)\
+    do { \
+	    CHECK_OVERFLOW_OP((a).r,-,(b).r)\
+	    CHECK_OVERFLOW_OP((a).i,-,(b).i)\
+	    (res).r=(a).r-(b).r;  (res).i=(a).i-(b).i; \
+    }while(0)
+#define C_ADDTO( res , a)\
+    do { \
+	    CHECK_OVERFLOW_OP((res).r,+,(a).r)\
+	    CHECK_OVERFLOW_OP((res).i,+,(a).i)\
+	    (res).r += (a).r;  (res).i += (a).i;\
+    }while(0)
+
+#define C_SUBFROM( res , a)\
+    do {\
+	    CHECK_OVERFLOW_OP((res).r,-,(a).r)\
+	    CHECK_OVERFLOW_OP((res).i,-,(a).i)\
+	    (res).r -= (a).r;  (res).i -= (a).i; \
+    }while(0)
+
+
+#ifdef FIXED_POINT
+#  define KISS_FFT_COS(phase)  floor(.5+SAMP_MAX * cos (phase))
+#  define KISS_FFT_SIN(phase)  floor(.5+SAMP_MAX * sin (phase))
+#  define HALF_OF(x) ((x)>>1)
+#elif defined(USE_SIMD)
+#  define KISS_FFT_COS(phase) _mm_set1_ps( cos(phase) )
+#  define KISS_FFT_SIN(phase) _mm_set1_ps( sin(phase) )
+#  define HALF_OF(x) ((x)*_mm_set1_ps(.5))
+#else
+#  define KISS_FFT_COS(phase) (kiss_fft_scalar) cos(phase)
+#  define KISS_FFT_SIN(phase) (kiss_fft_scalar) sin(phase)
+#  define HALF_OF(x) ((x)*.5)
+#endif
+
+#define  kf_cexp(x,phase) \
+	do{ \
+		(x)->r = KISS_FFT_COS(phase);\
+		(x)->i = KISS_FFT_SIN(phase);\
+	}while(0)
+
+
+/* a debugging function */
+#define pcpx(c)\
+    fprintf(stderr,"%g + %gi\n",(double)((c)->r),(double)((c)->i) )
+
+
+#ifdef KISS_FFT_USE_ALLOCA
+// define this to allow use of alloca instead of malloc for temporary buffers
+// Temporary buffers are used in two case: 
+// 1. FFT sizes that have "bad" factors. i.e. not 2,3 and 5
+// 2. "in-place" FFTs.  Notice the quotes, since kissfft does not really do an in-place transform.
+#include <alloca.h>
+#define  KISS_FFT_TMP_ALLOC(nbytes) alloca(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr) 
+#else
+#define  KISS_FFT_TMP_ALLOC(nbytes) KISS_FFT_MALLOC(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr) KISS_FFT_FREE(ptr)
+#endif

--- a/JNIBackends/rtl2832u/kissfft/kiss_fft.c
+++ b/JNIBackends/rtl2832u/kissfft/kiss_fft.c
@@ -1,0 +1,408 @@
+/*
+Copyright (c) 2003-2010, Mark Borgerding
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the author nor the names of any contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#include "_kiss_fft_guts.h"
+/* The guts header contains all the multiplication and addition macros that are defined for
+ fixed or floating point complex numbers.  It also delares the kf_ internal functions.
+ */
+
+static void kf_bfly2(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx * Fout2;
+    kiss_fft_cpx * tw1 = st->twiddles;
+    kiss_fft_cpx t;
+    Fout2 = Fout + m;
+    do{
+        C_FIXDIV(*Fout,2); C_FIXDIV(*Fout2,2);
+
+        C_MUL (t,  *Fout2 , *tw1);
+        tw1 += fstride;
+        C_SUB( *Fout2 ,  *Fout , t );
+        C_ADDTO( *Fout ,  t );
+        ++Fout2;
+        ++Fout;
+    }while (--m);
+}
+
+static void kf_bfly4(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        const size_t m
+        )
+{
+    kiss_fft_cpx *tw1,*tw2,*tw3;
+    kiss_fft_cpx scratch[6];
+    size_t k=m;
+    const size_t m2=2*m;
+    const size_t m3=3*m;
+
+
+    tw3 = tw2 = tw1 = st->twiddles;
+
+    do {
+        C_FIXDIV(*Fout,4); C_FIXDIV(Fout[m],4); C_FIXDIV(Fout[m2],4); C_FIXDIV(Fout[m3],4);
+
+        C_MUL(scratch[0],Fout[m] , *tw1 );
+        C_MUL(scratch[1],Fout[m2] , *tw2 );
+        C_MUL(scratch[2],Fout[m3] , *tw3 );
+
+        C_SUB( scratch[5] , *Fout, scratch[1] );
+        C_ADDTO(*Fout, scratch[1]);
+        C_ADD( scratch[3] , scratch[0] , scratch[2] );
+        C_SUB( scratch[4] , scratch[0] , scratch[2] );
+        C_SUB( Fout[m2], *Fout, scratch[3] );
+        tw1 += fstride;
+        tw2 += fstride*2;
+        tw3 += fstride*3;
+        C_ADDTO( *Fout , scratch[3] );
+
+        if(st->inverse) {
+            Fout[m].r = scratch[5].r - scratch[4].i;
+            Fout[m].i = scratch[5].i + scratch[4].r;
+            Fout[m3].r = scratch[5].r + scratch[4].i;
+            Fout[m3].i = scratch[5].i - scratch[4].r;
+        }else{
+            Fout[m].r = scratch[5].r + scratch[4].i;
+            Fout[m].i = scratch[5].i - scratch[4].r;
+            Fout[m3].r = scratch[5].r - scratch[4].i;
+            Fout[m3].i = scratch[5].i + scratch[4].r;
+        }
+        ++Fout;
+    }while(--k);
+}
+
+static void kf_bfly3(
+         kiss_fft_cpx * Fout,
+         const size_t fstride,
+         const kiss_fft_cfg st,
+         size_t m
+         )
+{
+     size_t k=m;
+     const size_t m2 = 2*m;
+     kiss_fft_cpx *tw1,*tw2;
+     kiss_fft_cpx scratch[5];
+     kiss_fft_cpx epi3;
+     epi3 = st->twiddles[fstride*m];
+
+     tw1=tw2=st->twiddles;
+
+     do{
+         C_FIXDIV(*Fout,3); C_FIXDIV(Fout[m],3); C_FIXDIV(Fout[m2],3);
+
+         C_MUL(scratch[1],Fout[m] , *tw1);
+         C_MUL(scratch[2],Fout[m2] , *tw2);
+
+         C_ADD(scratch[3],scratch[1],scratch[2]);
+         C_SUB(scratch[0],scratch[1],scratch[2]);
+         tw1 += fstride;
+         tw2 += fstride*2;
+
+         Fout[m].r = Fout->r - HALF_OF(scratch[3].r);
+         Fout[m].i = Fout->i - HALF_OF(scratch[3].i);
+
+         C_MULBYSCALAR( scratch[0] , epi3.i );
+
+         C_ADDTO(*Fout,scratch[3]);
+
+         Fout[m2].r = Fout[m].r + scratch[0].i;
+         Fout[m2].i = Fout[m].i - scratch[0].r;
+
+         Fout[m].r -= scratch[0].i;
+         Fout[m].i += scratch[0].r;
+
+         ++Fout;
+     }while(--k);
+}
+
+static void kf_bfly5(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx *Fout0,*Fout1,*Fout2,*Fout3,*Fout4;
+    int u;
+    kiss_fft_cpx scratch[13];
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx *tw;
+    kiss_fft_cpx ya,yb;
+    ya = twiddles[fstride*m];
+    yb = twiddles[fstride*2*m];
+
+    Fout0=Fout;
+    Fout1=Fout0+m;
+    Fout2=Fout0+2*m;
+    Fout3=Fout0+3*m;
+    Fout4=Fout0+4*m;
+
+    tw=st->twiddles;
+    for ( u=0; u<m; ++u ) {
+        C_FIXDIV( *Fout0,5); C_FIXDIV( *Fout1,5); C_FIXDIV( *Fout2,5); C_FIXDIV( *Fout3,5); C_FIXDIV( *Fout4,5);
+        scratch[0] = *Fout0;
+
+        C_MUL(scratch[1] ,*Fout1, tw[u*fstride]);
+        C_MUL(scratch[2] ,*Fout2, tw[2*u*fstride]);
+        C_MUL(scratch[3] ,*Fout3, tw[3*u*fstride]);
+        C_MUL(scratch[4] ,*Fout4, tw[4*u*fstride]);
+
+        C_ADD( scratch[7],scratch[1],scratch[4]);
+        C_SUB( scratch[10],scratch[1],scratch[4]);
+        C_ADD( scratch[8],scratch[2],scratch[3]);
+        C_SUB( scratch[9],scratch[2],scratch[3]);
+
+        Fout0->r += scratch[7].r + scratch[8].r;
+        Fout0->i += scratch[7].i + scratch[8].i;
+
+        scratch[5].r = scratch[0].r + S_MUL(scratch[7].r,ya.r) + S_MUL(scratch[8].r,yb.r);
+        scratch[5].i = scratch[0].i + S_MUL(scratch[7].i,ya.r) + S_MUL(scratch[8].i,yb.r);
+
+        scratch[6].r =  S_MUL(scratch[10].i,ya.i) + S_MUL(scratch[9].i,yb.i);
+        scratch[6].i = -S_MUL(scratch[10].r,ya.i) - S_MUL(scratch[9].r,yb.i);
+
+        C_SUB(*Fout1,scratch[5],scratch[6]);
+        C_ADD(*Fout4,scratch[5],scratch[6]);
+
+        scratch[11].r = scratch[0].r + S_MUL(scratch[7].r,yb.r) + S_MUL(scratch[8].r,ya.r);
+        scratch[11].i = scratch[0].i + S_MUL(scratch[7].i,yb.r) + S_MUL(scratch[8].i,ya.r);
+        scratch[12].r = - S_MUL(scratch[10].i,yb.i) + S_MUL(scratch[9].i,ya.i);
+        scratch[12].i = S_MUL(scratch[10].r,yb.i) - S_MUL(scratch[9].r,ya.i);
+
+        C_ADD(*Fout2,scratch[11],scratch[12]);
+        C_SUB(*Fout3,scratch[11],scratch[12]);
+
+        ++Fout0;++Fout1;++Fout2;++Fout3;++Fout4;
+    }
+}
+
+/* perform the butterfly for one stage of a mixed radix FFT */
+static void kf_bfly_generic(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m,
+        int p
+        )
+{
+    int u,k,q1,q;
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx t;
+    int Norig = st->nfft;
+
+    kiss_fft_cpx * scratch = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC(sizeof(kiss_fft_cpx)*p);
+
+    for ( u=0; u<m; ++u ) {
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            scratch[q1] = Fout[ k  ];
+            C_FIXDIV(scratch[q1],p);
+            k += m;
+        }
+
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            int twidx=0;
+            Fout[ k ] = scratch[0];
+            for (q=1;q<p;++q ) {
+                twidx += fstride * k;
+                if (twidx>=Norig) twidx-=Norig;
+                C_MUL(t,scratch[q] , twiddles[twidx] );
+                C_ADDTO( Fout[ k ] ,t);
+            }
+            k += m;
+        }
+    }
+    KISS_FFT_TMP_FREE(scratch);
+}
+
+static
+void kf_work(
+        kiss_fft_cpx * Fout,
+        const kiss_fft_cpx * f,
+        const size_t fstride,
+        int in_stride,
+        int * factors,
+        const kiss_fft_cfg st
+        )
+{
+    kiss_fft_cpx * Fout_beg=Fout;
+    const int p=*factors++; /* the radix  */
+    const int m=*factors++; /* stage's fft length/p */
+    const kiss_fft_cpx * Fout_end = Fout + p*m;
+
+#ifdef _OPENMP
+    // use openmp extensions at the 
+    // top-level (not recursive)
+    if (fstride==1 && p<=5)
+    {
+        int k;
+
+        // execute the p different work units in different threads
+#       pragma omp parallel for
+        for (k=0;k<p;++k) 
+            kf_work( Fout +k*m, f+ fstride*in_stride*k,fstride*p,in_stride,factors,st);
+        // all threads have joined by this point
+
+        switch (p) {
+            case 2: kf_bfly2(Fout,fstride,st,m); break;
+            case 3: kf_bfly3(Fout,fstride,st,m); break; 
+            case 4: kf_bfly4(Fout,fstride,st,m); break;
+            case 5: kf_bfly5(Fout,fstride,st,m); break; 
+            default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+        }
+        return;
+    }
+#endif
+
+    if (m==1) {
+        do{
+            *Fout = *f;
+            f += fstride*in_stride;
+        }while(++Fout != Fout_end );
+    }else{
+        do{
+            // recursive call:
+            // DFT of size m*p performed by doing
+            // p instances of smaller DFTs of size m, 
+            // each one takes a decimated version of the input
+            kf_work( Fout , f, fstride*p, in_stride, factors,st);
+            f += fstride*in_stride;
+        }while( (Fout += m) != Fout_end );
+    }
+
+    Fout=Fout_beg;
+
+    // recombine the p smaller DFTs 
+    switch (p) {
+        case 2: kf_bfly2(Fout,fstride,st,m); break;
+        case 3: kf_bfly3(Fout,fstride,st,m); break; 
+        case 4: kf_bfly4(Fout,fstride,st,m); break;
+        case 5: kf_bfly5(Fout,fstride,st,m); break; 
+        default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+    }
+}
+
+/*  facbuf is populated by p1,m1,p2,m2, ...
+    where 
+    p[i] * m[i] = m[i-1]
+    m0 = n                  */
+static 
+void kf_factor(int n,int * facbuf)
+{
+    int p=4;
+    double floor_sqrt;
+    floor_sqrt = floor( sqrt((double)n) );
+
+    /*factor out powers of 4, powers of 2, then any remaining primes */
+    do {
+        while (n % p) {
+            switch (p) {
+                case 4: p = 2; break;
+                case 2: p = 3; break;
+                default: p += 2; break;
+            }
+            if (p > floor_sqrt)
+                p = n;          /* no more factors, skip to end */
+        }
+        n /= p;
+        *facbuf++ = p;
+        *facbuf++ = n;
+    } while (n > 1);
+}
+
+/*
+ *
+ * User-callable function to allocate all necessary storage space for the fft.
+ *
+ * The return value is a contiguous block of memory, allocated with malloc.  As such,
+ * It can be freed with free(), rather than a kiss_fft-specific function.
+ * */
+kiss_fft_cfg kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem )
+{
+    kiss_fft_cfg st=NULL;
+    size_t memneeded = sizeof(struct kiss_fft_state)
+        + sizeof(kiss_fft_cpx)*(nfft-1); /* twiddle factors*/
+
+    if ( lenmem==NULL ) {
+        st = ( kiss_fft_cfg)KISS_FFT_MALLOC( memneeded );
+    }else{
+        if (mem != NULL && *lenmem >= memneeded)
+            st = (kiss_fft_cfg)mem;
+        *lenmem = memneeded;
+    }
+    if (st) {
+        int i;
+        st->nfft=nfft;
+        st->inverse = inverse_fft;
+
+        for (i=0;i<nfft;++i) {
+            const double pi=3.141592653589793238462643383279502884197169399375105820974944;
+            double phase = -2*pi*i / nfft;
+            if (st->inverse)
+                phase *= -1;
+            kf_cexp(st->twiddles+i, phase );
+        }
+
+        kf_factor(nfft,st->factors);
+    }
+    return st;
+}
+
+
+void kiss_fft_stride(kiss_fft_cfg st,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int in_stride)
+{
+    if (fin == fout) {
+        //NOTE: this is not really an in-place FFT algorithm.
+        //It just performs an out-of-place FFT into a temp buffer
+        kiss_fft_cpx * tmpbuf = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC( sizeof(kiss_fft_cpx)*st->nfft);
+        kf_work(tmpbuf,fin,1,in_stride, st->factors,st);
+        memcpy(fout,tmpbuf,sizeof(kiss_fft_cpx)*st->nfft);
+        KISS_FFT_TMP_FREE(tmpbuf);
+    }else{
+        kf_work( fout, fin, 1,in_stride, st->factors,st );
+    }
+}
+
+void kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout)
+{
+    kiss_fft_stride(cfg,fin,fout,1);
+}
+
+
+void kiss_fft_cleanup(void)
+{
+    // nothing needed any more
+}
+
+int kiss_fft_next_fast_size(int n)
+{
+    while(1) {
+        int m=n;
+        while ( (m%2) == 0 ) m/=2;
+        while ( (m%3) == 0 ) m/=3;
+        while ( (m%5) == 0 ) m/=5;
+        if (m<=1)
+            break; /* n is completely factorable by twos, threes, and fives */
+        n++;
+    }
+    return n;
+}

--- a/JNIBackends/rtl2832u/kissfft/kiss_fft.h
+++ b/JNIBackends/rtl2832u/kissfft/kiss_fft.h
@@ -1,0 +1,124 @@
+#ifndef KISS_FFT_H
+#define KISS_FFT_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ATTENTION!
+ If you would like a :
+ -- a utility that will handle the caching of fft objects
+ -- real-only (no imaginary time component ) FFT
+ -- a multi-dimensional FFT
+ -- a command-line utility to perform ffts
+ -- a command-line utility to perform fast-convolution filtering
+
+ Then see kfc.h kiss_fftr.h kiss_fftnd.h fftutil.c kiss_fastfir.c
+  in the tools/ directory.
+*/
+
+#ifdef USE_SIMD
+# include <xmmintrin.h>
+# define kiss_fft_scalar __m128
+#define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
+#define KISS_FFT_FREE _mm_free
+#else	
+#define KISS_FFT_MALLOC malloc
+#define KISS_FFT_FREE free
+#endif	
+
+
+#ifdef FIXED_POINT
+#include <sys/types.h>	
+# if (FIXED_POINT == 32)
+#  define kiss_fft_scalar int32_t
+# else	
+#  define kiss_fft_scalar int16_t
+# endif
+#else
+# ifndef kiss_fft_scalar
+/*  default is float */
+#   define kiss_fft_scalar float
+# endif
+#endif
+
+typedef struct {
+    kiss_fft_scalar r;
+    kiss_fft_scalar i;
+}kiss_fft_cpx;
+
+typedef struct kiss_fft_state* kiss_fft_cfg;
+
+/* 
+ *  kiss_fft_alloc
+ *  
+ *  Initialize a FFT (or IFFT) algorithm's cfg/state buffer.
+ *
+ *  typical usage:      kiss_fft_cfg mycfg=kiss_fft_alloc(1024,0,NULL,NULL);
+ *
+ *  The return value from fft_alloc is a cfg buffer used internally
+ *  by the fft routine or NULL.
+ *
+ *  If lenmem is NULL, then kiss_fft_alloc will allocate a cfg buffer using malloc.
+ *  The returned value should be free()d when done to avoid memory leaks.
+ *  
+ *  The state can be placed in a user supplied buffer 'mem':
+ *  If lenmem is not NULL and mem is not NULL and *lenmem is large enough,
+ *      then the function places the cfg in mem and the size used in *lenmem
+ *      and returns mem.
+ *  
+ *  If lenmem is not NULL and ( mem is NULL or *lenmem is not large enough),
+ *      then the function returns NULL and places the minimum cfg 
+ *      buffer size in *lenmem.
+ * */
+
+kiss_fft_cfg kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem); 
+
+/*
+ * kiss_fft(cfg,in_out_buf)
+ *
+ * Perform an FFT on a complex input buffer.
+ * for a forward FFT,
+ * fin should be  f[0] , f[1] , ... ,f[nfft-1]
+ * fout will be   F[0] , F[1] , ... ,F[nfft-1]
+ * Note that each element is complex and can be accessed like
+    f[k].r and f[k].i
+ * */
+void kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout);
+
+/*
+ A more generic version of the above function. It reads its input from every Nth sample.
+ * */
+void kiss_fft_stride(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int fin_stride);
+
+/* If kiss_fft_alloc allocated a buffer, it is one contiguous 
+   buffer and can be simply free()d when no longer needed*/
+#define kiss_fft_free free
+
+/*
+ Cleans up some memory that gets managed internally. Not necessary to call, but it might clean up 
+ your compiler output to call this before you exit.
+*/
+void kiss_fft_cleanup(void);
+	
+
+/*
+ * Returns the smallest integer k, such that k>=n and k has only "fast" factors (2,3,5)
+ */
+int kiss_fft_next_fast_size(int n);
+
+/* for real ffts, we need an even size */
+#define kiss_fftr_next_fast_size_real(n) \
+        (kiss_fft_next_fast_size( ((n)+1)>>1)<<1)
+
+#ifdef __cplusplus
+} 
+#endif
+
+#endif

--- a/JNIBackends/rtl2832u/kissfft/kiss_fftr.c
+++ b/JNIBackends/rtl2832u/kissfft/kiss_fftr.c
@@ -1,0 +1,159 @@
+/*
+Copyright (c) 2003-2004, Mark Borgerding
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the author nor the names of any contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "kiss_fftr.h"
+#include "_kiss_fft_guts.h"
+
+struct kiss_fftr_state{
+    kiss_fft_cfg substate;
+    kiss_fft_cpx * tmpbuf;
+    kiss_fft_cpx * super_twiddles;
+#ifdef USE_SIMD
+    void * pad;
+#endif
+};
+
+kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem)
+{
+    int i;
+    kiss_fftr_cfg st = NULL;
+    size_t subsize, memneeded;
+
+    if (nfft & 1) {
+        fprintf(stderr,"Real FFT optimization must be even.\n");
+        return NULL;
+    }
+    nfft >>= 1;
+
+    kiss_fft_alloc (nfft, inverse_fft, NULL, &subsize);
+    memneeded = sizeof(struct kiss_fftr_state) + subsize + sizeof(kiss_fft_cpx) * ( nfft * 3 / 2);
+
+    if (lenmem == NULL) {
+        st = (kiss_fftr_cfg) KISS_FFT_MALLOC (memneeded);
+    } else {
+        if (*lenmem >= memneeded)
+            st = (kiss_fftr_cfg) mem;
+        *lenmem = memneeded;
+    }
+    if (!st)
+        return NULL;
+
+    st->substate = (kiss_fft_cfg) (st + 1); /*just beyond kiss_fftr_state struct */
+    st->tmpbuf = (kiss_fft_cpx *) (((char *) st->substate) + subsize);
+    st->super_twiddles = st->tmpbuf + nfft;
+    kiss_fft_alloc(nfft, inverse_fft, st->substate, &subsize);
+
+    for (i = 0; i < nfft/2; ++i) {
+        double phase =
+            -3.14159265358979323846264338327 * ((double) (i+1) / nfft + .5);
+        if (inverse_fft)
+            phase *= -1;
+        kf_cexp (st->super_twiddles+i,phase);
+    }
+    return st;
+}
+
+void kiss_fftr(kiss_fftr_cfg st,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata)
+{
+    /* input buffer timedata is stored row-wise */
+    int k,ncfft;
+    kiss_fft_cpx fpnk,fpk,f1k,f2k,tw,tdc;
+
+    if ( st->substate->inverse) {
+        fprintf(stderr,"kiss fft usage error: improper alloc\n");
+        exit(1);
+    }
+
+    ncfft = st->substate->nfft;
+
+    /*perform the parallel fft of two real signals packed in real,imag*/
+    kiss_fft( st->substate , (const kiss_fft_cpx*)timedata, st->tmpbuf );
+    /* The real part of the DC element of the frequency spectrum in st->tmpbuf
+     * contains the sum of the even-numbered elements of the input time sequence
+     * The imag part is the sum of the odd-numbered elements
+     *
+     * The sum of tdc.r and tdc.i is the sum of the input time sequence. 
+     *      yielding DC of input time sequence
+     * The difference of tdc.r - tdc.i is the sum of the input (dot product) [1,-1,1,-1... 
+     *      yielding Nyquist bin of input time sequence
+     */
+ 
+    tdc.r = st->tmpbuf[0].r;
+    tdc.i = st->tmpbuf[0].i;
+    C_FIXDIV(tdc,2);
+    CHECK_OVERFLOW_OP(tdc.r ,+, tdc.i);
+    CHECK_OVERFLOW_OP(tdc.r ,-, tdc.i);
+    freqdata[0].r = tdc.r + tdc.i;
+    freqdata[ncfft].r = tdc.r - tdc.i;
+#ifdef USE_SIMD    
+    freqdata[ncfft].i = freqdata[0].i = _mm_set1_ps(0);
+#else
+    freqdata[ncfft].i = freqdata[0].i = 0;
+#endif
+
+    for ( k=1;k <= ncfft/2 ; ++k ) {
+        fpk    = st->tmpbuf[k]; 
+        fpnk.r =   st->tmpbuf[ncfft-k].r;
+        fpnk.i = - st->tmpbuf[ncfft-k].i;
+        C_FIXDIV(fpk,2);
+        C_FIXDIV(fpnk,2);
+
+        C_ADD( f1k, fpk , fpnk );
+        C_SUB( f2k, fpk , fpnk );
+        C_MUL( tw , f2k , st->super_twiddles[k-1]);
+
+        freqdata[k].r = HALF_OF(f1k.r + tw.r);
+        freqdata[k].i = HALF_OF(f1k.i + tw.i);
+        freqdata[ncfft-k].r = HALF_OF(f1k.r - tw.r);
+        freqdata[ncfft-k].i = HALF_OF(tw.i - f1k.i);
+    }
+}
+
+void kiss_fftri(kiss_fftr_cfg st,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata)
+{
+    /* input buffer timedata is stored row-wise */
+    int k, ncfft;
+
+    if (st->substate->inverse == 0) {
+        fprintf (stderr, "kiss fft usage error: improper alloc\n");
+        exit (1);
+    }
+
+    ncfft = st->substate->nfft;
+
+    st->tmpbuf[0].r = freqdata[0].r + freqdata[ncfft].r;
+    st->tmpbuf[0].i = freqdata[0].r - freqdata[ncfft].r;
+    C_FIXDIV(st->tmpbuf[0],2);
+
+    for (k = 1; k <= ncfft / 2; ++k) {
+        kiss_fft_cpx fk, fnkc, fek, fok, tmp;
+        fk = freqdata[k];
+        fnkc.r = freqdata[ncfft - k].r;
+        fnkc.i = -freqdata[ncfft - k].i;
+        C_FIXDIV( fk , 2 );
+        C_FIXDIV( fnkc , 2 );
+
+        C_ADD (fek, fk, fnkc);
+        C_SUB (tmp, fk, fnkc);
+        C_MUL (fok, tmp, st->super_twiddles[k-1]);
+        C_ADD (st->tmpbuf[k],     fek, fok);
+        C_SUB (st->tmpbuf[ncfft - k], fek, fok);
+#ifdef USE_SIMD        
+        st->tmpbuf[ncfft - k].i *= _mm_set1_ps(-1.0);
+#else
+        st->tmpbuf[ncfft - k].i *= -1;
+#endif
+    }
+    kiss_fft (st->substate, st->tmpbuf, (kiss_fft_cpx *) timedata);
+}

--- a/JNIBackends/rtl2832u/kissfft/kiss_fftr.h
+++ b/JNIBackends/rtl2832u/kissfft/kiss_fftr.h
@@ -1,0 +1,46 @@
+#ifndef KISS_FTR_H
+#define KISS_FTR_H
+
+#include "kiss_fft.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    
+/* 
+ 
+ Real optimized version can save about 45% cpu time vs. complex fft of a real seq.
+
+ 
+ 
+ */
+
+typedef struct kiss_fftr_state *kiss_fftr_cfg;
+
+
+kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem, size_t * lenmem);
+/*
+ nfft must be even
+
+ If you don't care to allocate space, use mem = lenmem = NULL 
+*/
+
+
+void kiss_fftr(kiss_fftr_cfg cfg,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata);
+/*
+ input timedata has nfft scalar points
+ output freqdata has nfft/2+1 complex points
+*/
+
+void kiss_fftri(kiss_fftr_cfg cfg,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata);
+/*
+ input freqdata has  nfft/2+1 complex points
+ output timedata has nfft scalar points
+*/
+
+#define kiss_fftr_free free
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -138,7 +138,6 @@ struct dongle_state
 	int      direct_sampling;
 	int      mute;
 	struct demod_state *demod_target;
-	struct controller_state *controller;
 };
 
 struct demod_state
@@ -1257,7 +1256,6 @@ void dongle_init(struct dongle_state *s)
 	s->direct_sampling = 0;
 	s->offset_tuning = 0;
 	s->demod_target = &demod;
-	s->controller = &controller;
 }
 
 void demod_init(struct demod_state *s)

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -1034,7 +1034,7 @@ double get_stabilized_rssi() {
 	/* Size of samples buffer */
 	int samplesSize = MAXIMUM_BUF_LENGTH / 16;
 	/* Buffer to receive samples for RSSI measurement */
-	void * samples = malloc(samplesSize * 2);
+	int16_t samples[samplesSize];
 	int samplesRead = 0;
 	int rssiTrend = 0;
 	double rssi = RSSI_INVALID;
@@ -1044,12 +1044,12 @@ double get_stabilized_rssi() {
 		lastRssi = rssi;
 
 		/* get a burst of samples to measure RSSI */
-		if (rtlsdr_read_sync(dongle.dev, samples, samplesSize, &samplesRead) < 0) {
+		if (rtlsdr_read_sync(dongle.dev, &samples, samplesSize, &samplesRead) < 0) {
 			fprintf(stderr, "\nget_stabilized_rssi: rtlsdr_read_sync failed\n");
 			return RSSI_INVALID;
 		}
 
-		rtlsdr_callback(samples, samplesRead, &dongle);
+		rtlsdr_callback((unsigned char *)&samples, samplesRead, &dongle);
 		pthread_rwlock_rdlock(&demod.rw);
 		rssi = dongle.demod_target->rssi;
 		pthread_rwlock_unlock(&demod.rw);

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -1137,7 +1137,6 @@ static void *controller_thread_fn(void *arg)
 					if (dongle.gain != dongle.gains[i]) {
 						dongle.gain = dongle.gains[i];
 						verbose_gain_set(dongle.dev, dongle.gain);
-						fprintf(stderr, "\nAGC: gain lowered to %d\n", dongle.gain);
 					}
 				} else if (dongle.gain < dongle.gains[dongle.gains_len-1]) {
 					/* check if we can increase gain without causing clipping */
@@ -1151,7 +1150,6 @@ static void *controller_thread_fn(void *arg)
 					if (newMin >= 0 && newMax <= 255) {
 						dongle.gain = dongle.gains[i];
 						verbose_gain_set(dongle.dev, dongle.gain);
-						fprintf(stderr, "\nAGC: gain raised to %d\n", dongle.gain);
 					}
 				}
 			}
@@ -1188,7 +1186,6 @@ static void *controller_thread_fn(void *arg)
 				}
 				rtlsdr_cancel_async(dongle.dev);
 				optimal_settings(freq);
-				fprintf(stderr, "\nSeek: currently at %d Hz (optimized to %d).\n", freq, dongle.freq);
 				rtlsdr_set_center_freq(dongle.dev, dongle.freq);
 
 				/* wait for tuner to settle */
@@ -1198,7 +1195,6 @@ static void *controller_thread_fn(void *arg)
 
 				/* measure RSSI */
 				rssi = get_stabilized_rssi();
-				fprintf(stderr, "\nSeek: rssi=%.2f\n", rssi);
 
 				pthread_rwlock_wrlock(&s->rw);
 				if (nearStart && (rssi < refRssi)) {
@@ -1223,7 +1219,6 @@ static void *controller_thread_fn(void *arg)
 						s->freq = freq;
 						rtlsdr_cancel_async(dongle.dev);
 						optimal_settings(freq);
-						fprintf(stderr, "\nSeek: stopped at %d Hz (optimized to %d).\n", freq, dongle.freq);
 						rtlsdr_set_center_freq(dongle.dev, dongle.freq);
 						s->retune = TUNE_NONE;
 					} else {
@@ -1236,7 +1231,6 @@ static void *controller_thread_fn(void *arg)
 					/* We're back at the original frequency and didn't find any stations */
 					rtlsdr_cancel_async(dongle.dev);
 					optimal_settings(freq);
-					fprintf(stderr, "\nSeek: aborted after one cycle at %d Hz, nearStart=%d, maxFreq=%d, refRssi=%.2f.\n", freq, nearStart, maxFreq, refRssi);
 					rtlsdr_set_center_freq(dongle.dev, dongle.freq);
 					s->retune = TUNE_NONE;
 				}

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -1019,9 +1019,11 @@ double get_stabilized_qual() {
 /**
  * @brief Waits for RSSI to stabilize, then returns the result.
  *
- * The RSSI is considered to have stabilized when two subsequent measurements differ by less than
- * 1 dB, or when three subsequent measurements fail to form a monotonic sequence. In either case,
- * the last RSSI measurement is returned.
+ * The RSSI is considered to have stabilized when three subsequent measurements fail to form a
+ * monotonic sequence. In that case, the last RSSI measurement is returned.
+ *
+ * A previous stabilization criterion of two subsequent measurements differing by less than 1 dB
+ * was dropped as it gave frequent false positives, resulting in good stations being skipped.
  */
 double get_stabilized_rssi() {
 	/* Size of samples buffer */
@@ -1051,10 +1053,7 @@ double get_stabilized_rssi() {
 
 		if (lastRssi == RSSI_INVALID) {
 			/* nothing to compare to yet */
-		} else if (abs(rssi - lastRssi) < 1)
-			/* RSSI changed by less than 1 dB, assume stable state */
-			return rssi;
-		else if (!rssiTrend) {
+		} else if (!rssiTrend) {
 			if (rssi < lastRssi)
 				rssiTrend = -1;
 			else if (rssi > lastRssi)

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -1433,7 +1433,7 @@ JNIEXPORT jint JNICALL Java_eu_jacquet80_rds_input_SdrGroupReader_setFrequency
 }
 
 
-JNIEXPORT jboolean JNICALL Java_eu_jacquet80_rds_input_SdrGroupReader_seek
+JNIEXPORT jboolean JNICALL Java_eu_jacquet80_rds_input_SdrGroupReader_nativeSeek
   (JNIEnv *env, jobject self, jboolean up) {
 	/* Suppress compiler warnings */
 	(void) env;

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -1222,7 +1222,7 @@ JNIEXPORT jboolean JNICALL Java_eu_jacquet80_rds_input_SdrGroupReader_open
 
 	/* Fall back to auto gain if we can't get supported gain levels */
 	if (!dongle.gains_len)
-		dongle.gain == AUTO_GAIN;
+		dongle.gain = AUTO_GAIN;
 
 	/* Set the tuner gain */
 	if (dongle.gain == AUTO_GAIN) {

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -953,16 +953,12 @@ static void *controller_thread_fn(void *arg)
 				//TODO do we need to communicate each seek step?
 				(*(s->env))->CallVoidMethod(s->env, s->self, s->onFrequencyChanged, (jint)(freq / 1.0e+3));
 
-				/* get two bursts of samples to measure RSSI */
-				/* FIXME: we have some issue due to which we get the RSSI of the previous frequency
-				 * (or something between both frequencies) after the first call to rtlsdr_callback.
-				 * This may be due to a race condition (lack of synchronization). As a workaround,
-				 * we're doing two passes and discarding the result from the first one.
-				 */
+				/* wait for tuner to settle and flush buffer */
+				usleep(5000);
 				if (rtlsdr_read_sync(dongle.dev, samples, samplesSize, &samplesRead) < 0)
 					fprintf(stderr, "\nSeek: rtlsdr_read_sync failed\n");
-				rtlsdr_callback(samples, samplesRead, &dongle);
 
+				/* get a burst of samples to measure RSSI */
 				if (rtlsdr_read_sync(dongle.dev, samples, samplesSize, &samplesRead) < 0)
 					fprintf(stderr, "\nSeek: rtlsdr_read_sync failed\n");
 				rtlsdr_callback(samples, samplesRead, &dongle);

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -1094,7 +1094,7 @@ static void *controller_thread_fn(void *arg)
 
 void dongle_init(struct dongle_state *s)
 {
-	s->rate = DEFAULT_SAMPLE_RATE;
+	s->rate = sampleRateOut;
 	s->gain = 0; // tenths of a dB
 	s->gains = NULL;
 	s->gains_len = 0;
@@ -1106,8 +1106,8 @@ void dongle_init(struct dongle_state *s)
 
 void demod_init(struct demod_state *s)
 {
-	s->rate_in = DEFAULT_SAMPLE_RATE;
-	s->rate_out = DEFAULT_SAMPLE_RATE;
+	s->rate_in = sampleRateOut;
+	s->rate_out = sampleRateOut;
 	s->downsample_passes = 1;  /* truthy placeholder */
 	s->comp_fir_size = 0;
 	s->prev_index = 0;

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -983,13 +983,17 @@ static void *controller_thread_fn(void *arg)
 					/* we're past the peak, tune directly to the strongest frequency */
 					freq = maxFreq;
 					s->freq = freq;
+					rtlsdr_cancel_async(dongle.dev);
 					optimal_settings(freq, demod.rate_in);
+					fprintf(stderr, "\nSeek: stopped at %d Hz (optimized to %d).\n", freq, dongle.freq);
 					rtlsdr_set_center_freq(dongle.dev, dongle.freq);
 					s->retune = TUNE_NONE;
 				} else if (freq == s->freq) {
 					/* We're back at the original frequency and didn't find any stations */
 					// TODO: should we run another round with RSSI_MIN_DX (DX mode)?
+					rtlsdr_cancel_async(dongle.dev);
 					optimal_settings(freq, demod.rate_in);
+					fprintf(stderr, "\nSeek: aborted after one cycle at %d Hz (optimized to %d).\n", freq, dongle.freq);
 					rtlsdr_set_center_freq(dongle.dev, dongle.freq);
 					s->retune = TUNE_NONE;
 				}

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -654,7 +654,7 @@ double dbm(int16_t *samples, int len, int step) {
 	dc = (double)(t*step) / (double)len;
 	err = t * 2 * dc - dc * dc * len;
 
-	return 10 * log10((p-err) / len) - 21;
+	return 10 * log10((p-err) / len);
 }
 
 /**

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -1036,8 +1036,6 @@ static void *controller_thread_fn(void *arg)
 				optimal_settings(freq);
 				fprintf(stderr, "\nSeek: currently at %d Hz (optimized to %d).\n", freq, dongle.freq);
 				rtlsdr_set_center_freq(dongle.dev, dongle.freq);
-				//TODO do we need to communicate each seek step?
-				(*(s->env))->CallVoidMethod(s->env, s->self, s->onFrequencyChanged, (jint)(freq / 1.0e+3));
 
 				/* wait for tuner to settle */
 				usleep(5000);

--- a/JNIBackends/rtl2832u/rtl_plugin.c
+++ b/JNIBackends/rtl2832u/rtl_plugin.c
@@ -1107,7 +1107,7 @@ void demod_init(struct demod_state *s)
 	s->rate_in = sampleRateOut;
 	s->rate_out = sampleRateOut;
 	s->downsample_passes = 1;  /* truthy placeholder */
-	s->comp_fir_size = 0;
+	s->comp_fir_size = 9;
 	s->prev_index = 0;
 	s->post_downsample = 1;  // once this works, default = 4
 	s->custom_atan = 0;

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -133,9 +133,23 @@ public class AudioBitReader extends BitReader {
 				Process pU;
 				Process pIQ;
 				Process pRaw;
-				String[] cmdU = {"sox", "-c", "5", "-r", Integer.toString(sampleRate), "-t", ".s16", "-", "dbg-out.wav"};
-				String[] cmdIQ = {"sox", "-c", "2", "-r", Integer.toString(sampleRate), "-t", ".s16", "-", "dbg-out-iq.wav"};
-				String[] cmdRaw = {"sox", "-c", "1", "-r", Integer.toString(sampleRate), "-t", ".s16", "-", "dbg-out-raw.wav"};
+				
+				String tempPath = "/tmp";
+				String pathSep ="/";
+				try {
+					tempPath = System.getProperty("java.io.tmpdir", tempPath);
+				} catch (Exception e) {
+					// NOP
+				}
+				try {
+					pathSep = System.getProperty("file.separator", pathSep);
+				} catch (Exception e) {
+					// NOP
+				}
+				
+				String[] cmdU = {"sox", "-c", "5", "-r", Integer.toString(sampleRate), "-t", ".s16", "-", tempPath + pathSep + "dbg-out.wav"};
+				String[] cmdIQ = {"sox", "-c", "2", "-r", Integer.toString(sampleRate), "-t", ".s16", "-", tempPath + pathSep + "dbg-out-iq.wav"};
+				String[] cmdRaw = {"sox", "-c", "1", "-r", Integer.toString(sampleRate), "-t", ".s16", "-", tempPath + pathSep + "dbg-out-raw.wav"};
 				DataOutputStream outU = null;
 				DataOutputStream outIQ = null;
 				DataOutputStream outRaw = null;

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -345,7 +345,6 @@ public class AudioBitReader extends BitReader {
 									} catch (IOException e) {
 										e.printStackTrace();
 									}
-								sbit = 0;
 								/* dbg-out.wav channel 4: dbit (demodulated RDS stream) */
 								outbuf = (short) (dbit * 16000);
 								if (outU != null)

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -105,24 +105,39 @@ public class AudioBitReader extends BitReader {
 		}
 		new Thread() {
 			public void run() {
-				// Array of audio samples retrieved, IBUFLEN samples, 16 bits (2 bytes) per sample
+				/* Array of audio samples retrieved, IBUFLEN samples, 16 bits (2 bytes) per sample */
 				short sample[]        = new short[IBUFLEN];
+				
+				/* Subcarrier frequency */
 				double fsc = FC_0;
 
+				/* Subcarrier phase */
 				double subcarr_phi    = 0;
+				
 				double subcarr_bb[]   = new double[] {0, 0};
+				
+				/* Clock phase offset */
 				double clock_offset   = 0;
+				
+				/* Clock phase */
 				double clock_phi      = 0;
+				
 				double lo_clock       = 0;
 				double prevclock      = 0;
 				double prev_bb        = 0;
+				
+				/* Subcarrier phase error */
 				double d_phi_sc       = 0;
 				
 				/* Subcarrier phase offset (relative to pilot tone) */
 				double sc_phi_offset  = 0;
 				
+				/* Pilot phase error */
 				double d_pphi         = 0;
+				
+				/* Clock phase error */
 				double d_cphi         = 0;
+				
 				double acc            = 0;
 				
 				/* Pilot tone frequency */
@@ -134,7 +149,8 @@ public class AudioBitReader extends BitReader {
 				double pilot_bb_i, pilot_bb_q;
 				double pll_beta       = 50;
 				
-				int bytesread; // note that this is really the number of samples (16-bit), not bytes
+				/* Number of samples (NOT bytes) read */
+				int bytesread;
 				
 				/* Whether a pilot tone has been detected (and will be used for tuning) */
 				boolean hasPilot;

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -52,7 +52,7 @@ public class AudioBitReader extends BitReader {
 	
 	/** 
 	 * Tolerance of RDS subcarrier frequency.
-	 * As per the specs, tolerance is +/- 6 Hz. We use twice the value to allow for some toleranc
+	 * As per the specs, tolerance is +/- 6 Hz. We use twice the value to allow for some tolerance
 	 * in the processing chain.
 	 */
 	private static final double FC_TOLERANCE = 12.0;

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -74,6 +74,9 @@ public class AudioBitReader extends BitReader {
 	/** Sample rate, or frames per second */
 	private final int sampleRate;
 	
+	/** Decimation factor, determined based on the sample rate */
+	private final int decimate;
+	
 	/** A queue for the bits decoded from the audio stream. */
 	private final ArrayBlockingQueue<Boolean> bits = new ArrayBlockingQueue<Boolean>(OBUFLEN);
 
@@ -97,6 +100,7 @@ public class AudioBitReader extends BitReader {
 	public AudioBitReader(DataInputStream stream, int srate) {
 		this.in = stream;
 		this.sampleRate = srate;
+		this.decimate = this.sampleRate / 7125;
 		this.audioMirrorSource = new PipedInputStream();
 		try {
 			this.audioMirrorSink = new DataOutputStream(new PipedOutputStream(audioMirrorSource));
@@ -301,7 +305,7 @@ public class AudioBitReader extends BitReader {
 						}
 						
 						/* Decimate band-limited signal */
-						if (numsamples % 8 == 0) {
+						if (numsamples % decimate == 0) {
 							/* 1187.5 Hz clock */
 
 							clock_phi = subcarr_phi / 48.0 + clock_offset;
@@ -396,7 +400,7 @@ public class AudioBitReader extends BitReader {
 									}
 
 								t += 1.0/sampleRate;
-								if ((stats != null) && (numsamples % 128 == 0))
+								if ((stats != null) && (numsamples % (decimate * 16) == 0))
 									// qua (quality) is not implemented so far
 									stats.printf("%f,%f,%f,%f,%f,%f,%f\n", t, hasPilot ? fp : 0, fsc, d_phi_sc, subcarr_bb[0], subcarr_bb[1], clock_offset);
 							}

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -43,6 +43,8 @@ import biz.source_code.dsp.filter.FilterPassType;
 import biz.source_code.dsp.filter.IirFilter;
 import biz.source_code.dsp.filter.IirFilterCoefficients;
 import biz.source_code.dsp.filter.IirFilterDesignFisher;
+import biz.source_code.dsp.math.Complex;
+import biz.source_code.dsp.transform.Dft;
 
 public class AudioBitReader extends BitReader {
 	private static final boolean DEBUG = false; // set to true to enable debug output
@@ -109,8 +111,14 @@ public class AudioBitReader extends BitReader {
 		}
 		new Thread() {
 			public void run() {
-				/* Array of audio samples retrieved, IBUFLEN samples, 16 bits (2 bytes) per sample */
+				/* Array of audio samples retrieved, 16 bits (2 bytes) per sample */
 				short sample[]        = new short[IBUFLEN];
+				
+				/* Audio samples for DFT (responsiveness is controlled by array size) */
+				double dftIn[]        = new double[sampleRate * 2];
+				
+				/* Next index of dftIn to write to */
+				int dftInPos          = 0;
 				
 				/* Subcarrier frequency */
 				double fsc = FC_0;
@@ -156,8 +164,14 @@ public class AudioBitReader extends BitReader {
 				/* Number of samples (NOT bytes) read */
 				int bytesread;
 				
-				/* Whether a pilot tone has been detected (and will be used for tuning) */
-				boolean hasPilot;
+				/* Whether a pilot tone has been detected */
+				boolean hasPilot      = false;
+				
+				/* Whether to use the pilot tone for tuning */
+				boolean usePilot      = false;
+				
+				/* Whether a RDS subcarrier has been detected */
+				boolean hasSubcarrier = false;
 
 				int numsamples = 0;
 				
@@ -166,7 +180,7 @@ public class AudioBitReader extends BitReader {
 				
 				IirFilterCoefficients lpPllCoeffs = IirFilterDesignFisher.design(FilterPassType.lowpass,
 						FilterCharacteristicsType.butterworth, 1, 0, 2200.0 / sampleRate, 2200.0 / sampleRate);
-
+				
 				IirFilter lp2400iFilter = new IirFilter(lp2400Coeffs);
 				IirFilter lp2400qFilter = new IirFilter(lp2400Coeffs);
 				IirFilter lpPllScFilter = new IirFilter(lpPllCoeffs);
@@ -270,8 +284,55 @@ public class AudioBitReader extends BitReader {
 								} catch (IOException e) {
 									e.printStackTrace();
 								}
+						
+						/* collect samples for DFT */
+						if (i + dftInPos < dftIn.length)
+							dftIn[i + dftInPos] = sample[i];
+					}
+					
+					dftInPos += bytesread;
+					
+					if (dftInPos >= dftIn.length) {
+						/* We have enough samples to do a DFT */
+						dftInPos = 0;
+						
+						/* detect pilot tone */
+						double dft17k = Dft.goertzelSingle(dftIn, 0, dftIn.length, 17000 * dftIn.length / sampleRate, true).abs();
+						double dft19k = Dft.goertzelSingle(dftIn, 0, dftIn.length, 19000 * dftIn.length / sampleRate, true).abs();
+						double dft21k = Dft.goertzelSingle(dftIn, 0, dftIn.length, 21000 * dftIn.length / sampleRate, true).abs();
 
-						if (hasPilot) {
+						if ((dft17k < dft19k) && (dft19k > dft21k)) {
+							if (!hasPilot)
+								System.err.println("\nPilot tone detected");
+							hasPilot = true;
+						} else {
+							if (hasPilot)
+								System.err.println("\nPilot tone lost");
+							hasPilot = false;
+						}
+
+						/* detect RDS subcarrier */
+						double dft54k = Dft.goertzelSingle(dftIn, 0, dftIn.length, 54000 * dftIn.length / sampleRate, true).abs();
+						double dft56k = Dft.goertzelSingle(dftIn, 0, dftIn.length, 56175 * dftIn.length / sampleRate, true).abs();
+						double dft57k = Dft.goertzelSingle(dftIn, 0, dftIn.length, 57000 * dftIn.length / sampleRate, true).abs();
+						double dft58k = Dft.goertzelSingle(dftIn, 0, dftIn.length, 57825 * dftIn.length / sampleRate, true).abs();
+
+						if ((dft54k < dft56k) && (dft56k > dft57k) && (dft57k < dft58k)) {
+							if (!hasSubcarrier)
+								System.err.println("\nSubcarrier detected");
+							hasSubcarrier = true;
+							// TODO reset tuner
+						} else {
+							if (hasSubcarrier)
+								System.err.println("\nSubcarrier lost");
+							hasSubcarrier = false;
+						}
+					}
+					
+					// TODO break if no subcarrier present
+					
+					for (i = 0; i < bytesread; i++) {
+						if (hasPilot && usePilot) {
 							/* Pilot tone recovery */
 							pilot_phi  += 2 * Math.PI * fp * (1.0/sampleRate);
 							pilot_bb_i  = lpPllPIFilter.step(Math.cos(pilot_phi) * sample[i] / 32768.0);

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -47,6 +47,9 @@ import biz.source_code.dsp.filter.IirFilterDesignFisher;
 public class AudioBitReader extends BitReader {
 	private static final boolean DEBUG = false; // set to true to enable debug output
 	
+	/** Pilot tone frequency */
+	private static final double FP_0 = 19000.0;
+	
 	/** RDS carrier frequency */
 	private static final double FC_0 = 57000.0;
 	
@@ -114,9 +117,27 @@ public class AudioBitReader extends BitReader {
 				double prevclock      = 0;
 				double prev_bb        = 0;
 				double d_phi_sc       = 0;
+				
+				/* Subcarrier phase offset (relative to pilot tone) */
+				double sc_phi_offset  = 0;
+				
+				double d_pphi         = 0;
 				double d_cphi         = 0;
 				double acc            = 0;
+				
+				/* Pilot tone frequency */
+				double fp = FP_0;
+				
+				/* Pilot phase */
+				double pilot_phi      = 0;
+				
+				double pilot_bb_i, pilot_bb_q;
+				double pll_beta       = 50;
+				
 				int bytesread; // note that this is really the number of samples (16-bit), not bytes
+				
+				/* Whether a pilot tone has been detected (and will be used for tuning) */
+				boolean hasPilot;
 
 				int numsamples = 0;
 				
@@ -128,7 +149,10 @@ public class AudioBitReader extends BitReader {
 
 				IirFilter lp2400iFilter = new IirFilter(lp2400Coeffs);
 				IirFilter lp2400qFilter = new IirFilter(lp2400Coeffs);
-				IirFilter lpPllFilter = new IirFilter(lpPllCoeffs);
+				IirFilter lpPllScFilter = new IirFilter(lpPllCoeffs);
+				IirFilter lpPllPIFilter = new IirFilter(lpPllCoeffs);
+				IirFilter lpPllPQFilter = new IirFilter(lpPllCoeffs);
+				IirFilter lpPllPPhiFilter = new IirFilter(lpPllCoeffs);
 				
 				// for debugging only
 				double t = 0;
@@ -192,12 +216,14 @@ public class AudioBitReader extends BitReader {
 					
 					try {
 						stats = new PrintStream(new File(tempPath, "stats.csv"));
-						stats.print("t,fp,d_phi_sc,subcarr_bb_re,subcarr_bb_im,clock_offset\n");
+						stats.print("t,fp,fsc,d_phi_sc,subcarr_bb_re,subcarr_bb_im,clock_offset\n");
 					} catch (FileNotFoundException e) {
 						e.printStackTrace();
 						stats = null;
 					}
 				}
+				
+				hasPilot = true; // TODO drop this once we can detect the presence of a pilot tone
 
 				while (true) {
 					bytesread = 0;
@@ -233,18 +259,39 @@ public class AudioBitReader extends BitReader {
 								}
 						}
 
-						/* Subcarrier downmix & phase recovery */
+						if (hasPilot) {
+							/* Pilot tone recovery */
+							pilot_phi  += 2 * Math.PI * fp * (1.0/sampleRate);
+							pilot_bb_i  = lpPllPIFilter.step(Math.cos(pilot_phi) * sample[i] / 32768.0);
+							pilot_bb_q  = lpPllPQFilter.step(Math.sin(pilot_phi) * sample[i] / 32768.0);
+							
+							d_pphi      = lpPllPPhiFilter.step(pilot_bb_q * pilot_bb_i);
+							pilot_phi  -= pll_beta * d_pphi;
+							fp         -= pll_beta * d_pphi;
+							fsc         = fp * 3;
+							
+							/* Subcarrier downmix & phase recovery */
+							subcarr_phi    = pilot_phi * 3.0 + sc_phi_offset;
+							
+							subcarr_bb[0]  = lp2400iFilter.step(sample[i] / 32768.0 * Math.cos(subcarr_phi));
+							subcarr_bb[1]  = lp2400qFilter.step(sample[i] / 32768.0 * Math.sin(subcarr_phi));
 
-						subcarr_phi    += 2 * Math.PI * fsc * (1.0/sampleRate);
-						subcarr_bb[0]  = lp2400iFilter.step(sample[i] / 32768.0 * Math.cos(subcarr_phi));
-						subcarr_bb[1]  = lp2400qFilter.step(sample[i] / 32768.0 * Math.sin(subcarr_phi));
+							d_phi_sc = lpPllScFilter.step(subcarr_bb[1] * subcarr_bb[0]);
+							
+							sc_phi_offset -= pll_beta * d_phi_sc;
+						} else {
+							/* Subcarrier downmix & phase recovery */
+							subcarr_phi    += 2 * Math.PI * fsc * (1.0/sampleRate);
+							
+							subcarr_bb[0]  = lp2400iFilter.step(sample[i] / 32768.0 * Math.cos(subcarr_phi));
+							subcarr_bb[1]  = lp2400qFilter.step(sample[i] / 32768.0 * Math.sin(subcarr_phi));
 
-						double pll_beta = 50;
-
-						d_phi_sc = lpPllFilter.step(subcarr_bb[1] * subcarr_bb[0]);
-						subcarr_phi -= pll_beta * d_phi_sc;
-						fsc         -= 0.5 * pll_beta * d_phi_sc;
-
+							d_phi_sc = lpPllScFilter.step(subcarr_bb[1] * subcarr_bb[0]);
+							
+							subcarr_phi -= pll_beta * d_phi_sc;
+							fsc         -= 0.5 * pll_beta * d_phi_sc;
+						}
+						
 						/* 1187.5 Hz clock */
 
 						clock_phi = subcarr_phi / 48.0 + clock_offset;
@@ -346,7 +393,7 @@ public class AudioBitReader extends BitReader {
 							t += 1.0/sampleRate;
 							if ((stats != null) && (numsamples % 125 == 0))
 								// qua (quality) is not implemented so far
-								stats.printf("%f,%f,%f,%f,%f,%f\n", t, fsc, d_phi_sc, subcarr_bb[0], subcarr_bb[1], clock_offset);
+								stats.printf("%f,%f,%f,%f,%f,%f,%f\n", t, hasPilot ? fp : 0, fsc, d_phi_sc, subcarr_bb[0], subcarr_bb[1], clock_offset);
 						}
 
 						prev_bb = subcarr_bb[0];

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -296,7 +296,6 @@ public class AudioBitReader extends BitReader {
 						if (numsamples % decimate == 0) {
 							/* Reset subcarrier frequency if it is outside tolerance range */
 							if ((fsc > FC_0 + FC_TOLERANCE) || (fsc < FC_0 - FC_TOLERANCE)) {
-								System.err.println("\nSubcarrier frequency outside tolerance range, resetting");
 								fsc = FC_0;
 							}
 

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -244,15 +244,14 @@ public class AudioBitReader extends BitReader {
 					}
 					
 					if (bytesread < 1) break;
-
+					
 					for (i = 0; i < bytesread; i++) {
-						if (isPlaying)
-							if (audioMirrorSink != null)
-								try {
-									audioMirrorSink.writeShort(Short.reverseBytes(sample[i]));
-								} catch (IOException e) {
-									e.printStackTrace();
-								}
+						if (isPlaying && (audioMirrorSink != null))
+							try {
+								audioMirrorSink.writeShort(Short.reverseBytes(sample[i]));
+							} catch (IOException e) {
+								e.printStackTrace();
+							}
 
 						/* Subcarrier downmix & phase recovery */
 
@@ -264,13 +263,14 @@ public class AudioBitReader extends BitReader {
 						subcarr_phi -= pll_beta * d_phi_sc;
 						fsc         -= 0.5 * pll_beta * d_phi_sc;
 						
-						if ((fsc > FC_0 + FC_TOLERANCE) || (fsc < FC_0 - FC_TOLERANCE)) {
-							System.err.println("\nSubcarrier frequency outside tolerance range, resetting");
-							fsc = FC_0;
-						}
-
 						/* Decimate band-limited signal */
 						if (numsamples % decimate == 0) {
+							/* Reset subcarrier frequency if it is outside tolerance range */
+							if ((fsc > FC_0 + FC_TOLERANCE) || (fsc < FC_0 - FC_TOLERANCE)) {
+								System.err.println("\nSubcarrier frequency outside tolerance range, resetting");
+								fsc = FC_0;
+							}
+
 							/* 1187.5 Hz clock */
 
 							clock_phi = subcarr_phi / 48.0 + clock_offset;

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -142,10 +142,13 @@ public class AudioBitReader extends BitReader {
 				
 				double acc            = 0;
 				
+				double pll_beta       = 50;
+
 				/* Number of samples (NOT bytes) read */
 				int bytesread;
 
 				int numsamples = 0;
+				int i;
 				
 				IirFilterCoefficients lp2400Coeffs = IirFilterDesignFisher.design(FilterPassType.lowpass,
 						FilterCharacteristicsType.butterworth, 5, 0, 2000.0 / sampleRate, 2000.0 / sampleRate);
@@ -242,7 +245,6 @@ public class AudioBitReader extends BitReader {
 					
 					if (bytesread < 1) break;
 
-					int i;
 					for (i = 0; i < bytesread; i++) {
 						if (isPlaying)
 							if (audioMirrorSink != null)
@@ -254,11 +256,9 @@ public class AudioBitReader extends BitReader {
 
 						/* Subcarrier downmix & phase recovery */
 
-						subcarr_phi    += 2 * Math.PI * fsc * (1.0/sampleRate);
+						subcarr_phi    += 2 * Math.PI * fsc / (double) sampleRate;
 						subcarr_bb[0]  = lp2400iFilter.step(sample[i] / 32768.0 * Math.cos(subcarr_phi));
 						subcarr_bb[1]  = lp2400qFilter.step(sample[i] / 32768.0 * Math.sin(subcarr_phi));
-
-						double pll_beta = 50;
 
 						d_phi_sc = lpPllFilter.step(subcarr_bb[1] * subcarr_bb[0]);
 						subcarr_phi -= pll_beta * d_phi_sc;

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -192,7 +192,7 @@ public class AudioBitReader extends BitReader {
 					
 					try {
 						stats = new PrintStream(new File(tempPath, "stats.csv"));
-						stats.print("t,fp,d_phi_sc,clock_offset\n");
+						stats.print("t,fp,d_phi_sc,subcarr_bb_re,subcarr_bb_im,clock_offset\n");
 					} catch (FileNotFoundException e) {
 						e.printStackTrace();
 						stats = null;
@@ -346,7 +346,7 @@ public class AudioBitReader extends BitReader {
 							t += 1.0/sampleRate;
 							if ((stats != null) && (numsamples % 125 == 0))
 								// qua (quality) is not implemented so far
-								stats.printf("%f,%f,%f,%f\n", t, fsc, d_phi_sc, clock_offset);
+								stats.printf("%f,%f,%f,%f,%f,%f\n", t, fsc, d_phi_sc, subcarr_bb[0], subcarr_bb[1], clock_offset);
 						}
 
 						prev_bb = subcarr_bb[0];

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -50,6 +50,13 @@ public class AudioBitReader extends BitReader {
 	/** RDS carrier frequency */
 	private static final double FC_0 = 57000.0;
 	
+	/** 
+	 * Tolerance of RDS subcarrier frequency.
+	 * As per the specs, tolerance is +/- 6 Hz. We use twice the value to allow for some toleranc
+	 * in the processing chain.
+	 */
+	private static final double FC_TOLERANCE = 12.0;
+	
 	/** Input buffer length, in samples */
 	private static final int IBUFLEN = 4096;
 	
@@ -256,6 +263,11 @@ public class AudioBitReader extends BitReader {
 						d_phi_sc = lpPllFilter.step(subcarr_bb[1] * subcarr_bb[0]);
 						subcarr_phi -= pll_beta * d_phi_sc;
 						fsc         -= 0.5 * pll_beta * d_phi_sc;
+						
+						if ((fsc > FC_0 + FC_TOLERANCE) || (fsc < FC_0 - FC_TOLERANCE)) {
+							System.err.println("\nSubcarrier frequency outside tolerance range, resetting");
+							fsc = FC_0;
+						}
 
 						/* Decimate band-limited signal */
 						if (numsamples % decimate == 0) {

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
@@ -175,28 +175,21 @@ public class SdrGroupReader extends TunerGroupReader {
 	 * RSSI by reading from the chip's 0x0a register, which provides a 8-bit value (0-255). This is
 	 * then multiplied by 873 (which would allow for a 0-75 input range without causing an
 	 * overflow). Silicon Labs documentation (AN230) anecdotally indicates a practical range of 0
-	 * to +45 dB, whereas measurements with a RTL2832U found values in the range of -30 to +15 dB.
-	 * (The threshold for RDS reception with a RTL2832U was found around -10 dB, slightly less than
-	 * half the range.)
-	 * 
-	 * By adding 30 dB to the RSSI as reported by the RTL2832U and applying the same multiplier as
-	 * the Si470x driver, signal strengths are similar to what the Si470x driver reports under
-	 * similar conditions (albeit slightly stronger, which is congruent with the fact that a
-	 * RTL2832U SDR tends to yield better reception).
+	 * to +45 dB, which is roughly congruent with the values reported by the RTL2832U.
 	 * 
 	 * If the actual signal strength is outside the boundaries, the nearest boundary is returned.
 	 * 
 	 * The return value of this function can be calculated from signal strength as follows:
-	 * signal = (rssi + 30) * 873
+	 * signal = rssi * 873
 	 * 
 	 * Vice versa:
-	 * rssi = signal / 873 - 30;
+	 * rssi = signal / 873;
 	 * 
 	 * @return Signal strength
 	 */
 	@Override
 	public int getSignalStrength() {
-		int signal = (int)((getRssi() + 30) * 873);
+		int signal = (int)((getRssi()) * 873);
 		if (signal < 0)
 			signal = 0;
 		else if (signal > 0xFFFF)

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
@@ -345,7 +345,7 @@ public class SdrGroupReader extends TunerGroupReader {
 			try {
 				AudioFormat outFormat =  
 						new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, outSampleRate, 16, 1, 2, outSampleRate, false);
-				DataLine.Info outInfo = new DataLine.Info(SourceDataLine.class, outFormat, 4*250000);
+				DataLine.Info outInfo = new DataLine.Info(SourceDataLine.class, outFormat, 4 * outSampleRate);
 				outLine = (SourceDataLine) AudioSystem.getLine(outInfo);
 				outLine.open(outFormat);
 			} catch(Exception e) {

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
@@ -25,7 +25,7 @@ import eu.jacquet80.rds.util.MathUtil;
 
 public class SdrGroupReader extends TunerGroupReader {
 	/** The sample rate at which we receive data from the tuner. */
-	private static final int sampleRate = 250000;
+	private static final int sampleRate = 128000;
 	
 	/** The sample rate for audio output. */
 	private static final int outSampleRate = 48000;

--- a/RDSSurveyor/src/eu/jacquet80/rds/util/MathUtil.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/util/MathUtil.java
@@ -1,0 +1,14 @@
+package eu.jacquet80.rds.util;
+
+public final class MathUtil {
+	/**
+	 * @brief Returns the greatest common divisor of two positive integers.
+	 * 
+	 * Note that both arguments must be positive. The result is not specified if this method is
+	 * called with negative arguments.
+	 */
+	public static int gcd(int a, int b) {
+		if (b == 0) return a;
+		return gcd(b, a%b);
+	}
+}


### PR DESCRIPTION
This pull request fixes a few issues with the RTL2832U backend and adds some new features:

- Builds correctly with JDK 1.8 on Linux
- Fixed compiler warnings
- Several improvements for seek:
  - Drop fixed RSSI threshold in favor of local RSSI peaks combined with signal quality
  - More reliable RSSI measurements during seek
  - Mute during seek
  - Report new frequency only after seek completes (same as Si470x)
- Signal strengths now comparable to Si470x
- Audio playback now supported (mono only, no stereo decoding yet)
- Lower `SdrGroupReader` sample rate to reduce processor load
- Control gain in software (as all-hardware AGC proved to be unreliable)
- Debug functionality (if enabled) now writes to default temp dir and includes SCV stats
- Performance and signal quality tweaks