### PR TITLE
Allow using RDS Surveyor as a TMC tuner/parsing library

### DIFF
--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -490,9 +490,9 @@ public class AlertC extends ODA {
 		/** The country code of the service that sent the message (from RDS PI). */
 		private final int cc;
 		/** The Location Table Number (LTN) of the service that sent the message. */
-		private final int ltn;
+		private int ltn;
 		/** The Service ID (SID). */
-		private final int sid;
+		private int sid;
 		/** Whether the message has an INTER-ROAD location, i.e. uses a foreign location table */
 		private final boolean interroad;
 		/** The country code of the location. */
@@ -1513,6 +1513,30 @@ public class AlertC extends ODA {
 		public boolean isFullyResolved() {
 			return ((cc >= 0) && (ltn >= 0) && (sid >= 0)
 					&& ((locationInfo != null) || (location >= LOCATION_ALL_LISTENERS)));
+		}
+		
+		/**
+		 * @brief Sets the LocationTable Number (LTN) and Service Identifier (SID).
+		 * 
+		 * This sets the LTN and SID for the originating service. This method is intended for
+		 * situations in which the LTN and/or SID have not yet been received since the last station
+		 * change, but cached values are available.
+		 * 
+		 * Attempting to change a valid LTN or SID to a different value will result in an
+		 * {@link IllegalArgumentException}. Changing an LTN or SID to the same value is a no-op.
+		 * 
+		 * @param ltn The Location Table Number (LTN)
+		 * @param sid The Service Identifier (SID)
+		 */
+		public void setService(int ltn, int sid) {
+			if ((this.ltn == -1 || this.ltn == ltn)
+					&& (this.sid == -1 || this.sid == sid)) {
+				this.ltn = ltn;
+				if (!interroad)
+					this.fltn = ltn;
+				this.sid = sid;
+			} else
+				throw new IllegalArgumentException("LTN and SID cannot be changed after being set");
 		}
 
 		private void setLocation(int location) {

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -1851,8 +1851,13 @@ public class AlertC extends ODA {
 
 	
 	public static class InformationBlock {
-		/** The enclosing TMC message */
-		private Message message;
+		/** Primary key for persistent storage, -1 if no corresponding DB record exists */
+		private int dbId = -1;
+		
+		/** The country code to be used in decoding the diversion route locations. */
+		private int cc;
+		/** The Location Table Number (LTN) to be used in decoding the diversion route locations. */
+		private int ltn;
 		
 		private int length = -1;
 		private int speed = -1;
@@ -1865,12 +1870,14 @@ public class AlertC extends ODA {
 		private final List<Integer> diversionRoute = new ArrayList<Integer>();
 
 		public InformationBlock(Message message, int eventCode) {
-			this.message = message;
+			this.cc = message.fcc;
+			this.ltn = message.ltn;
 			addEvent(eventCode);
 		}
 		
 		public InformationBlock(Message message) {
-			this.message = message;
+			this.cc = message.fcc;
+			this.ltn = message.ltn;
 			this.currentEvent = null;
 		}
 		
@@ -1908,7 +1915,7 @@ public class AlertC extends ODA {
 		public List<TMCLocation> getDiversion() {
 			List<TMCLocation> res = new LinkedList<TMCLocation>();
 			for (int lcid : diversionRoute) {
-				TMCLocation location = TMC.getLocation(String.format("%X", message.fcc), message.fltn, lcid);
+				TMCLocation location = TMC.getLocation(String.format("%X", cc), ltn, lcid);
 				if (location == null)
 					return new LinkedList<TMCLocation>();
 				res.add(location);
@@ -1958,7 +1965,7 @@ public class AlertC extends ODA {
 		 */
 		private void setDestination(int destination) {
 			this.destination = destination;
-			this.destinationInfo = TMC.getLocation(String.format("%X", message.fcc), message.fltn, destination);
+			this.destinationInfo = TMC.getLocation(String.format("%X", cc), ltn, destination);
 		}
 
 		@Override
@@ -1990,7 +1997,7 @@ public class AlertC extends ODA {
 				res.append("Diversion route: " + diversionRoute).append("\n");
 				for (int lcid : diversionRoute) {
 					res.append("#").append(lcid);
-					TMCLocation location = TMC.getLocation(String.format("%X", message.fcc), message.fltn, lcid);
+					TMCLocation location = TMC.getLocation(String.format("%X", cc), ltn, lcid);
 					if (location != null)
 						res.append(location).append("\n");
 				}
@@ -2026,7 +2033,7 @@ public class AlertC extends ODA {
 				res.append("Diversion route: " + diversionRoute).append("<br><ul>");
 				for (int lcid : diversionRoute) {
 					res.append("<li>").append(lcid);
-					TMCLocation location = TMC.getLocation(String.format("%X", message.fcc), message.fltn, lcid);
+					TMCLocation location = TMC.getLocation(String.format("%X", cc), ltn, lcid);
 					if (location != null)
 						res.append("<blockquote>").append(location.html()).append("</blockquote>");
 				}

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -831,7 +831,7 @@ public class AlertC extends ODA {
 				nature = this.informationBlocks.get(0).events.get(0).nature;
 			
 			if (reversedDurationType)
-				invertDurationType();
+				durationType = durationType.invert();
 			
 			this.complete = true;
 		}
@@ -2154,14 +2154,6 @@ public class AlertC extends ODA {
 				res.append("</font>");
 			}
 			return res.toString();
-		}
-
-
-		private void invertDurationType() {
-			if (this.durationType == EventDurationType.DYNAMIC)
-				this.durationType = EventDurationType.LONGER_LASTING;
-			else
-				this.durationType = EventDurationType.DYNAMIC;
 		}
 	}
 	

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -1782,6 +1782,11 @@ public class AlertC extends ODA {
 		}
 		
 
+		public int getQuantifier() {
+			return quantifier;
+		}
+
+
 		@Override
 		public String toString() {
 			String text;

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -75,6 +75,7 @@ public class AlertC extends ODA {
 	private List<Message> messages = new ArrayList<Message>();
 	private Comparator<Message> messageComparator = new DefaultComparator();
 	private Message currentMessage;
+	private boolean storeCancellationMessages = false;
 	private Bitstream multiGroupBits;
 
 	private int currentContIndex = -1;
@@ -340,7 +341,7 @@ public class AlertC extends ODA {
 			
 			// 2) second we just need to add the current message
 			// (unless it is a cancellation message)
-			if(! currentMessage.isCancellation()) {
+			if(storeCancellationMessages || !currentMessage.isCancellation()) {
 				messages.add(currentMessage);
 				Collections.sort(messages, messageComparator);
 			}
@@ -413,6 +414,15 @@ public class AlertC extends ODA {
 		return onInfo;
 	}
 	
+	
+	/**
+	 * @brief Returns whether this instance stores cancellation messages in its list of messages,
+	 * rather than discarding them after all matching messages have been deleted from the list.
+	 */
+	public boolean isStoreCancellationMessages() {
+		return storeCancellationMessages;
+	}
+	
 	/**
 	 * @brief Sets a new comparator, which will be used to sort the list of messages.
 	 * 
@@ -428,6 +438,21 @@ public class AlertC extends ODA {
 			fireChangeListeners();
 		}
 	}
+	
+	
+	/**
+	 * @brief Specifies whether cancellation messages will be stored.
+	 * 
+	 * If true, cancellation messages will be stored in the list of messages just like any other
+	 * message. If false, cancellation messages will be discarded after all matching messages have
+	 * been deleted from the list. Default is false.
+	 * 
+	 * @param value
+	 */
+	public void storeCancellationMessages(boolean value) {
+		storeCancellationMessages = value;
+	}
+	
 	
 	private static class Bitstream {
 		private long bits;

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -697,12 +697,17 @@ public class AlertC extends ODA {
 		 * instance, this method calls the {@link InformationBlock#accept(MessageVisitor)} of each
 		 * {@link InformationBlock} in the message. 
 		 * 
-		 * @param visitor
+		 * @param visitor The visitor
+		 * @param parentFirst If true, the parent will be visited before its first child. If false,
+		 * the parent will be visited after its last child.
 		 */
-		public void accept(MessageVisitor visitor) {
-			visitor.visit(this);
+		public void accept(MessageVisitor visitor, boolean parentFirst) {
+			if (parentFirst)
+				visitor.visit(this);
 			for (InformationBlock ib : informationBlocks)
-				ib.accept(visitor);
+				ib.accept(visitor, parentFirst);
+			if (!parentFirst)
+				visitor.visit(this);
 		}
 
 		/**
@@ -1822,12 +1827,17 @@ public class AlertC extends ODA {
 		 * the current instance, this method calls the {@link Event#accept(MessageVisitor)} of each
 		 * {@link Event} in the information block. 
 		 * 
-		 * @param visitor
+		 * @param visitor The visitor
+		 * @param parentFirst If true, the parent will be visited before its first child. If false,
+		 * the parent will be visited after its last child.
 		 */
-		public void accept(MessageVisitor visitor) {
-			visitor.visit(this);
+		public void accept(MessageVisitor visitor, boolean parentFirst) {
+			if (parentFirst)
+				visitor.visit(this);
 			for (Event e : events)
 				e.accept(visitor);
+			if (!parentFirst)
+				visitor.visit(this);
 		}
 
 		/**

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -230,7 +230,6 @@ public class AlertC extends ODA {
 									console.printf(" ignoring, bad continuity index (was %d), probably missed groups", currentContIndex);
 									currentContIndex = -1;
 									nextGroupExpected = -1;
-									builder.reset();
 								} else if(groupNumber != nextGroupExpected) {
 									console.print(" ignoring, next expected is #" + nextGroupExpected);
 								} else {

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -572,7 +572,7 @@ public class AlertC extends ODA {
 		public final int extent;
 		// extent, affected by 1.6 and 1.7   (= number of steps, see ISO 81419-1, par. 5.5.2 a: 31 steps max
 		/** The time at which the message was received. */
-		private Date date = null;
+		private final Date date;
 		/** The time zone to be used for persistence times based on "midnight". */
 		public final TimeZone timeZone;
 		/** The country code of the service that sent the message (from RDS PI). */
@@ -582,19 +582,19 @@ public class AlertC extends ODA {
 		/** The Service ID (SID). */
 		private int sid;
 		/** Whether the location code is encrypted. */
-		private boolean encrypted;
+		private final boolean encrypted;
 		/** Whether the message has an INTER-ROAD location, i.e. uses a foreign location table */
 		public final boolean interroad;
 		/** The country code of the location. */
-		private int fcc = -1;
+		private final int fcc;
 		/** The Foreign Location Table Number (LTN), i.e. the LTN for the location. */
 		private int fltn = -1;
 		/** The raw location code. */
-		private int location;
+		private final int location;
 		/** The resolved location, if the location is contained in a previously loaded TMC location table. */
-		private TMCLocation locationInfo;
+		private final TMCLocation locationInfo;
 		/** Whether the event affects both directions. */
-		private boolean bidirectional = true;
+		private final boolean bidirectional;
 		/** The coordinates of the event. */
 		private float[] coords = null;
 		/** The auxiliary coordinates of the event. */
@@ -628,7 +628,7 @@ public class AlertC extends ODA {
 		public final EventUrgency urgency;
 		
 		public final boolean spoken;      // TODO default   // 1.4
-		private boolean diversion = false;							   // 1.5
+		private final boolean diversion;							   // 1.5
 		
 		private List<InformationBlock> informationBlocks = new ArrayList<AlertC.InformationBlock>();
 		
@@ -673,6 +673,8 @@ public class AlertC extends ODA {
 			this.location = location;
 			if (!this.encrypted)
 				this.locationInfo = TMC.getLocation(String.format("%X", this.fcc), this.fltn, location);
+			else
+				this.locationInfo = null;
 			this.ltn = ltn;
 			this.nature = nature;
 			this.sid = sid;
@@ -1725,10 +1727,10 @@ public class AlertC extends ODA {
 		/** The Location Table Number (LTN) to be used in decoding the diversion route locations. */
 		private int ltn;
 		
-		private int length = -1;
-		private int speed = -1;
+		private final int length;
+		private final int speed;
 		public final int destination;
-		private TMCLocation destinationInfo = null;
+		private final TMCLocation destinationInfo;
 
 		private final List<Event> events;
 		
@@ -1928,13 +1930,13 @@ public class AlertC extends ODA {
 		private int ltn;
 
 		public final TMCEvent tmcEvent;
-		private EventUrgency urgency;
-		private EventNature nature;
-		private EventDurationType durationType;
+		private final EventUrgency urgency;
+		private final EventNature nature;
+		private final EventDurationType durationType;
 		public final int sourceLocation;
 
 		public final int quantifier;
-		private List<SupplementaryInfo> suppInfo = new ArrayList<SupplementaryInfo>();
+		private final List<SupplementaryInfo> suppInfo;
 
 		/**
 		 * @brief Constructs an event with the given parameters.

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -1471,6 +1471,18 @@ public class AlertC extends ODA {
 			return ltn;
 		}
 		
+		/**
+		 * @brief Returns a list of all {@link InformationBlock}s in this message.
+		 */
+		public List<InformationBlock> getInformationBlocks() {
+			List<InformationBlock> result = new ArrayList<InformationBlock>();
+			
+			for(InformationBlock ib : informationBlocks)
+				result.add(ib);
+			
+			return result;
+		}
+
 		public List<Integer> getEvents() {
 			List<Integer> result = new ArrayList<Integer>();
 			
@@ -1706,6 +1718,38 @@ public class AlertC extends ODA {
 			this.currentEvent = null;
 		}
 		
+		/**
+		 * @brief Returns a list of all events in this information block.
+		 */
+		public List<Event> getEvents() {
+			List<Event> result = new ArrayList<Event>();
+			
+			for(Event e : events) {
+				result.add(e);
+			}
+			
+			return result;
+		}
+		
+		/**
+		 * @brief Returns the length of the route affected.
+		 * 
+		 * @return The length of the route affected in km, -1 if unknown. Return values greater
+		 * than 100 are to be interpreted as "100 km or more" rather than literally.
+		 */
+		public int getLength() {
+			return length;
+		}
+		
+		/**
+		 * @brief Returns the speed limit.
+		 * 
+		 * @return The speed limit in km/h, or -1 if unknown.
+		 */
+		public int getSpeed() {
+			return speed;
+		}
+		
 		private void addEvent(int eventCode) {
 			this.currentEvent = new Event(eventCode);
 			events.add(this.currentEvent);		
@@ -1782,19 +1826,39 @@ public class AlertC extends ODA {
 		}
 		
 
-		public int getQuantifier() {
-			return quantifier;
+		/**
+		 * @brief Returns the supplementary information phrases associated with this event.
+		 */
+		public List<SupplementaryInfo> getSupplementaryInfo() {
+			List<SupplementaryInfo> result = new ArrayList<SupplementaryInfo>();
+			
+			for(SupplementaryInfo si : suppInfo)
+				result.add(si);
+			
+			return result;
 		}
 
 
-		@Override
-		public String toString() {
+		/**
+		 * @brief Generates a formatted event description.
+		 * 
+		 * If the event has a quantifier, this method returns the quantifier string for the event
+		 * with the quantifier parsed and inserted. Otherwise, the generic description is returned.
+		 */
+		public String getText() {
 			String text;
 			if(quantifier != -1) {
 				text = tmcEvent.textQ.replace("$Q", tmcEvent.formatQuantifier(quantifier));
 			} else {
 				text = tmcEvent.text;
 			}
+			return text;
+		}
+
+
+		@Override
+		public String toString() {
+			String text = getText();
 			StringBuffer res = new StringBuffer("[").append(tmcEvent.code).append("] ").append(text);
 			res.append(", urgency=").append(urgency);
 			res.append(", nature=").append(nature);
@@ -1806,12 +1870,7 @@ public class AlertC extends ODA {
 		}
 		
 		public String html() {
-			String text;
-			if(quantifier != -1) {
-				text = tmcEvent.textQ.replace("$Q", tmcEvent.formatQuantifier(quantifier));
-			} else {
-				text = tmcEvent.text;
-			}
+			String text = getText();
 			StringBuffer res = new StringBuffer("[").append(tmcEvent.code).append("] <b>").append(text).append("</b/>");
 			res.append(", urgency=").append(urgency);
 			res.append(", nature=").append(nature);
@@ -1826,7 +1885,8 @@ public class AlertC extends ODA {
 			}
 			return res.toString();
 		}
-		
+
+
 		private void invertDurationType() {
 			if (this.durationType == EventDurationType.DYNAMIC)
 				this.durationType = EventDurationType.LONGER_LASTING;

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -868,7 +868,7 @@ public class AlertC extends ODA {
 		 * Tells whether it is a cancellation message.
 		 * @return
 		 */
-		private boolean isCancellation() {
+		public boolean isCancellation() {
 			if(this.informationBlocks.size() > 0) {
 				InformationBlock ib1 = this.informationBlocks.get(0);
 				if(ib1.events.size() > 0) {
@@ -1499,6 +1499,10 @@ public class AlertC extends ODA {
 		 */
 		public boolean isDiversionAvailable() {
 			return diversion;
+		}
+		
+		public void setUpdateCount(int newCount) {
+			updateCount = newCount;
 		}
 		
 		/**

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -973,6 +973,8 @@ public class AlertC extends ODA {
 			res.append("CC: ").append(String.format("%X", fcc));
 			res.append(", LTN: ").append(fltn);
 			res.append(", Location: ").append(location);
+			if (encrypted)
+				res.append(" (encrypted)");
 			res.append(", extent=" + this.extent);
 			res.append(", ").append(this.bidirectional ? "bi" : "mono").append("directional");
 			res.append(", growth direction ").append(this.direction == 0 ? "+" : "-");
@@ -1063,6 +1065,8 @@ public class AlertC extends ODA {
 			res.append("CC: ").append(String.format("%X", fcc));
 			res.append(", LTN: ").append(fltn);
 			res.append(", Location: ").append(location);
+			if (encrypted)
+				res.append(" (encrypted)");
 			res.append(", extent=" + this.extent);
 			res.append(", ").append(this.bidirectional ? "bi" : "mono").append("directional");
 			res.append(", growth direction ").append(this.direction == 0 ? "+" : "-");

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -2515,6 +2515,7 @@ public class AlertC extends ODA {
 			this.date = null;
 			this.diversion = false;
 			this.direction = -1;
+			this.duration = 0;
 			this.durationType = null;
 			this.extent = 0;
 			this.fcc = -1;

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -1483,6 +1483,13 @@ public class AlertC extends ODA {
 			return result;
 		}
 		
+		/**
+		 * @brief Returns the date and time at which this message was received.
+		 */
+		public Date getTimestamp() {
+			return (Date) date.clone();
+		}
+		
 		public int getUpdateCount() {
 			return updateCount;
 		}

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -1222,6 +1222,19 @@ public class AlertC extends ODA {
 		
 		
 		/**
+		 * @brief Returns the direction of the message.
+		 * 
+		 * In most cases, the return value should be evaluated together with
+		 * {@link #isBidirectional()}.
+		 * 
+		 * @return 0 for positive, 1 for negative
+		 */
+		public int getDirection() {
+			return direction;
+		}
+		
+		
+		/**
 		 * @brief Returns a name for the location which can be displayed to the user.
 		 * 
 		 * The display name, together with the road number (if any), identifies the location of the event.
@@ -1546,6 +1559,8 @@ public class AlertC extends ODA {
 		
 		/**
 		 * @brief Returns whether the message affects both directions.
+		 * 
+		 * To get the direction, call {@link #getDirection()}.
 		 */
 		public boolean isBidirectional() {
 			return bidirectional;

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -1519,6 +1519,32 @@ public class AlertC extends ODA {
 		}
 		
 		/**
+		 * @brief Whether the message has a secondary location.
+		 * 
+		 * If {@code checkValidity} is false, this method will simply look at the extent and return
+		 * true if the extent is greater than zero, false otherwise.
+		 * 
+		 * If {@code checkValidity} is true, this method will try to resolve the secondary location
+		 * and return true only if the combination of primary location, direction and extent
+		 * resolve to a valid location which is different from the primary location. It will also
+		 * return false if no location table is present to resolve the primary location.
+		 * 
+		 * @param checkValidity
+		 * 
+		 * @return
+		 */
+		public boolean hasSecondaryLocation(boolean checkValidity) {
+			if (extent <= 0)
+				return false;
+			if (!checkValidity)
+				return true;
+			TMCLocation secondary = locationInfo.getOffset(this.extent, this.direction);
+			if ((secondary == null) || (locationInfo.equals(secondary)))
+				return false;
+			return true;
+		}
+		
+		/**
 		 * @brief Returns whether the message affects both directions.
 		 */
 		public boolean isBidirectional() {

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -71,7 +71,7 @@ public class AlertC extends ODA {
 	private int mode = 0;			// mode (basic or enhanced)
 	private int sid = -1;			// Service ID
 	
-	private Map<Integer, TMCOtherNetwork> otherNetworks = new HashMap<Integer, TMCOtherNetwork>();
+	private Map<Integer, TMCOtherNetwork> otherNetworks = Collections.synchronizedMap(new HashMap<Integer, TMCOtherNetwork>());
 	private List<Message> messages = new ArrayList<Message>();
 	private Comparator<Message> messageComparator = new DefaultComparator();
 	private Message currentMessage;
@@ -263,12 +263,13 @@ public class AlertC extends ODA {
 				console.print("Tuning Info: ");
 				
 				TMCOtherNetwork on = null;
-				if(addr >= 6 && addr <= 9){
-					on = otherNetworks.get(blocks[3]);
-					if (on == null)
-						on = new TMCOtherNetwork(blocks[3]);
-					otherNetworks.put(blocks[3], on);
-				}
+				if (addr >= 6 && addr <= 9)
+					synchronized(otherNetworks) {
+						on = otherNetworks.get(blocks[3]);
+						if (on == null)
+							on = new TMCOtherNetwork(blocks[3]);
+						otherNetworks.put(blocks[3], on);
+					}
 				
 				String newOnInfo = null;
 
@@ -294,10 +295,12 @@ public class AlertC extends ODA {
 					
 				case 8:
 					newOnInfo = String.format("ON.PI=%04X, ON.PI=%04X", blocks[2], blocks[3]);
-					on = otherNetworks.get(blocks[2]);
-					if (on == null)
-						on = new TMCOtherNetwork(blocks[2]);
-					otherNetworks.put(blocks[2], on);
+					synchronized(otherNetworks) {
+						on = otherNetworks.get(blocks[2]);
+						if (on == null)
+							on = new TMCOtherNetwork(blocks[2]);
+						otherNetworks.put(blocks[2], on);
+					}
 					break;
 					
 				case 9:

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -594,7 +594,7 @@ public class AlertC extends ODA {
 		/** The resolved location, if the location is contained in a previously loaded TMC location table. */
 		private TMCLocation locationInfo;
 		/** Whether the default directionality of the message should be reversed. */
-		public boolean reversedDirectionality = false;
+		private boolean reversedDirectionality = false;
 		/** Whether the event affects both directions. */
 		private boolean bidirectional = true;
 		/** The coordinates of the event. */

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -1578,6 +1578,29 @@ public class AlertC extends ODA {
 			return (Date) date.clone();
 		}
 		
+		/**
+		 * @brief Returns the primary location of the message.
+		 * 
+		 * The primary location is the location of the disruption, or the location at which the
+		 * driver would exit from the affected stretch of road.
+		 */
+		public TMCLocation getPrimaryLocation() {
+			return locationInfo;
+		}
+
+		/**
+		 * @brief Returns the secondary location of the message.
+		 * 
+		 * The secondary location is the location at which the driver would first encounter the
+		 * signaled condition. If the message has an extent of zero, this method will return the
+		 * primary location.
+		 */
+		public TMCLocation getSecondaryLocation() {
+			if (extent <= 0)
+				return locationInfo;
+			return locationInfo.getOffset(this.extent, this.direction);
+		}
+
 		public int getUpdateCount() {
 			return updateCount;
 		}

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -569,12 +569,12 @@ public class AlertC extends ODA {
 		/** Direction of queue growth (0 for positive, 1 for negative). */
 		private final int direction;
 		/** The geographic extent of the event, expressed as a number of steps from 0 to 31. */
-		private int extent;		
+		public int extent;
 		// extent, affected by 1.6 and 1.7   (= number of steps, see ISO 81419-1, par. 5.5.2 a: 31 steps max
 		/** The time at which the message was received. */
 		private Date date = null;
 		/** The time zone to be used for persistence times based on "midnight". */
-		private TimeZone timeZone;
+		public TimeZone timeZone;
 		/** The country code of the service that sent the message (from RDS PI). */
 		private final int cc;
 		/** The Location Table Number (LTN) of the service that sent the message. */
@@ -584,7 +584,7 @@ public class AlertC extends ODA {
 		/** Whether the location code is encrypted. */
 		private boolean encrypted;
 		/** Whether the message has an INTER-ROAD location, i.e. uses a foreign location table */
-		private final boolean interroad;
+		public final boolean interroad;
 		/** The country code of the location. */
 		private int fcc = -1;
 		/** The Foreign Location Table Number (LTN), i.e. the LTN for the location. */
@@ -594,7 +594,7 @@ public class AlertC extends ODA {
 		/** The resolved location, if the location is contained in a previously loaded TMC location table. */
 		private TMCLocation locationInfo;
 		/** Whether the default directionality of the message should be reversed. */
-		private boolean reversedDirectionality = false;
+		public boolean reversedDirectionality = false;
 		/** Whether the event affects both directions. */
 		private boolean bidirectional = true;
 		/** The coordinates of the event. */
@@ -615,10 +615,10 @@ public class AlertC extends ODA {
 		 * message. In this case, the nature and duration type of the last event received before the
 		 * duration field apply (the last event may be the first group event).
 		 */
-		private EventDurationType durationType = null;
-		private int duration = 0;		// 0- duration (0 if not set)
-		private int startTime = -1;		// 7- start time
-		private int stopTime = -1;		// 8- stop time
+		public EventDurationType durationType = null;
+		public int duration = 0;		// 0- duration (0 if not set)
+		public int startTime = -1;		// 7- start time
+		public int stopTime = -1;		// 8- stop time
 		// 13- cross linkage to source
 
 		/**
@@ -626,14 +626,14 @@ public class AlertC extends ODA {
 		 * 
 		 * The value is taken from the TMC event which was followed by the duration.
 		 */
-		private EventNature nature = null;
+		public EventNature nature = null;
 
 		/** Number of levels by which to increase or decrease default urgency. */
 		private int increasedUrgency = 0;
 		/** The urgency of the message. */
-		private EventUrgency urgency;
+		public EventUrgency urgency;
 		
-		private boolean spoken = false;      // TODO default   // 1.4
+		public boolean spoken = false;      // TODO default   // 1.4
 		private boolean diversion = false;							   // 1.5
 		
 		private List<InformationBlock> informationBlocks = new ArrayList<AlertC.InformationBlock>();
@@ -1791,7 +1791,7 @@ public class AlertC extends ODA {
 		
 		private int length = -1;
 		private int speed = -1;
-		private int destination = -1;
+		public int destination = -1;
 		private TMCLocation destinationInfo = null;
 
 		private final List<Event> events;
@@ -1855,6 +1855,21 @@ public class AlertC extends ODA {
 				res.add(location);
 			}
 			return res;
+		}
+
+		/**
+		 * @brief Returns the location codes which make up the diversion route.
+		 * 
+		 * @return A list of location codes. An empty list is returned if no diversion is specified
+		 * or if one or more location codes cannot be resolved.
+		 */
+		public List<Integer> getDiversionLcids() {
+			List<Integer> result = new ArrayList<Integer>();
+
+			for (int lcid : diversionRoute)
+				result.add(lcid);
+
+			return result;
 		}
 
 		/**
@@ -1979,13 +1994,13 @@ public class AlertC extends ODA {
 		/** The Location Table Number (LTN) to be used in decoding the source location. */
 		private int ltn;
 
-		private TMCEvent tmcEvent;
+		public final TMCEvent tmcEvent;
 		private EventUrgency urgency;
 		private EventNature nature;
 		private EventDurationType durationType;
-		private int sourceLocation = -1;
+		public final int sourceLocation;
 
-		private int quantifier = -1;
+		public final int quantifier;
 		private List<SupplementaryInfo> suppInfo = new ArrayList<SupplementaryInfo>();
 
 		/**

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -2450,15 +2450,15 @@ public class AlertC extends ODA {
 			if (this.informationBlocks.isEmpty())
 				throw new IllegalStateException("Cannot create a message without information blocks");
 
-			if (this.urgency == null)
-				for (InformationBlock ib : informationBlocks)
-					for (Event e : ib.events) {
-						this.bidirectional &= e.tmcEvent.bidirectional;
-						if (this.urgency == null)
-							this.urgency = e.urgency;
-						else
-							this.urgency = EventUrgency.max(urgency, e.urgency);
-					}
+			boolean needsUrgency = (this.urgency == null);
+			for (InformationBlock ib : informationBlocks)
+				for (Event e : ib.events) {
+					this.bidirectional &= e.tmcEvent.bidirectional;
+					if (this.urgency == null)
+						this.urgency = e.urgency;
+					else if (needsUrgency)
+						this.urgency = EventUrgency.max(urgency, e.urgency);
+				}
 
 			/*
 			 * TODO: what if we have a multi-event message with different duration types and no

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -688,6 +688,21 @@ public class AlertC extends ODA {
 			this.eventForDuration = this.currentInformationBlock.currentEvent;
 		}
 		
+		/**
+		 * @brief Accepts a {@link MessageVisitor}.
+		 * 
+		 * After invoking the visitor’s {@link MessageVisitor#visit(Message)} method on the current
+		 * instance, this method calls the {@link InformationBlock#accept(MessageVisitor)} of each
+		 * {@link InformationBlock} in the message. 
+		 * 
+		 * @param visitor
+		 */
+		public void accept(MessageVisitor visitor) {
+			visitor.visit(this);
+			for (InformationBlock ib : informationBlocks)
+				ib.accept(visitor);
+		}
+
 		public void addField(int label, int value) {
 			switch(label) {
 			// duration
@@ -1860,6 +1875,21 @@ public class AlertC extends ODA {
 		}
 		
 		/**
+		 * @brief Accepts a {@link MessageVisitor}.
+		 * 
+		 * After invoking the visitor’s {@link MessageVisitor#visit(InformationBlock)} method on
+		 * the current instance, this method calls the {@link Event#accept(MessageVisitor)} of each
+		 * {@link Event} in the information block. 
+		 * 
+		 * @param visitor
+		 */
+		public void accept(MessageVisitor visitor) {
+			visitor.visit(this);
+			for (Event e : events)
+				e.accept(visitor);
+		}
+
+		/**
 		 * @brief Returns the destination information.
 		 * 
 		 * @return The location for the destination, or null if no destination is specified or if
@@ -2031,6 +2061,16 @@ public class AlertC extends ODA {
 		
 
 		/**
+		 * @brief Accepts a {@link MessageVisitor}.
+		 * 
+		 * @param visitor
+		 */
+		public void accept(MessageVisitor visitor) {
+			visitor.visit(this);
+		}
+
+
+		/**
 		 * @brief Returns the supplementary information phrases associated with this event.
 		 */
 		public List<SupplementaryInfo> getSupplementaryInfo() {
@@ -2151,5 +2191,11 @@ public class AlertC extends ODA {
 			/* Finally compare by extent */
 			return lhs.extent - rhs.extent;
 		}
+	}
+
+	public static interface MessageVisitor {
+		public void visit(Message message);
+		public void visit(InformationBlock informationBlock);
+		public void visit(Event event);
 	}
 }

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -2558,15 +2558,6 @@ public class AlertC extends ODA {
 		}
 
 		/**
-		 * @brief Copies data from an existing message.
-		 * 
-		 * @param message
-		 */
-		public void setMessage(Message message) {
-			// TODO
-		}
-
-		/**
 		 * @brief Sets the event nature for the entire message.
 		 * 
 		 * This will override previous implicit value set by {@link #setDuration(int)}. However,

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/LocationComparator.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/LocationComparator.java
@@ -1,0 +1,88 @@
+package eu.jacquet80.rds.app.oda.tmc;
+
+import java.util.Comparator;
+
+/**
+ * @brief A comparator for sorting TMC locations.
+ * 
+ * This comparator sorts locations based on their order along a linear feature, according to
+ * the direction given in the constructor. If the two locations have a parent relationship
+ * (e.g. a segment and a point on that segment), the parent is sorted before the child. If two
+ * locations are not part of the same linear feature and have no parent-child relationship,
+ * they are not sortable and considered equal.
+ */
+public class LocationComparator implements Comparator<TMCLocation> {
+	private final boolean negativeDirection;
+
+	public LocationComparator(boolean negativeDirection) {
+		super();
+		this.negativeDirection = negativeDirection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
+	 * 
+	 * @return -1 if lhs < rhs, +1 if lhs > rhs, 0 otherwise
+	 */
+	@Override
+	public int compare(TMCLocation lhs, TMCLocation rhs) {
+		/* trivially, if locations are equal, return 0 */
+		if (lhs.equals(rhs))
+			return 0;
+		
+		/* handle parent relationships */
+		if (rhs.isChildOf(lhs))
+			return -1;
+		if (lhs.isChildOf(rhs))
+			return 1;
+
+		/* if both are points, cycle through offsets */
+		if ((lhs instanceof TMCPoint) && (rhs instanceof TMCPoint)) {
+			TMCPoint lneg = ((TMCPoint) lhs).getNegOffset();
+			TMCPoint lpos = ((TMCPoint) lhs).getPosOffset();
+			while (!rhs.equals(lneg) && !rhs.equals(lpos) && (lneg != null || lpos != null)) {
+				if (lneg != null)
+					lneg = lneg.getNegOffset();
+				if (lpos != null)
+					lpos = lpos.getPosOffset();
+			}
+
+			if (rhs.equals(lneg))
+				return negativeDirection ? -1 : 1;
+			else if (rhs.equals(lpos))
+				return negativeDirection ? 1 : -1;
+			else
+				return 0;
+		}
+
+		/* if both are segments, do the same but also consider nested segments */
+		if ((lhs instanceof Segment) && (rhs instanceof Segment)) {
+			Segment lneg = ((Segment) lhs).getNegOffset();
+			Segment lpos = ((Segment) lhs).getPosOffset();
+			while (!rhs.equals(lneg) && !rhs.equals(lpos) && (lneg != null || lpos != null)) {
+				if (lneg != null)
+					lneg = lneg.getNegOffset();
+				if (lpos != null)
+					lpos = lpos.getPosOffset();
+			}
+
+			if (rhs.equals(lneg))
+				return negativeDirection ? -1 : 1;
+			else if (rhs.equals(lpos))
+				return negativeDirection ? 1 : -1;
+			else {
+				int res = 0;
+				if (((Segment) lhs).segment != null)
+					res = compare(((Segment) lhs).segment, rhs);
+				if ((res == 0) && (((Segment) rhs).segment != null))
+					res = compare (lhs, ((Segment) rhs).segment);
+				return res;
+			}
+		}
+
+		/* nothing applies, items are not sortable */
+		return 0;
+	}
+
+}

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/Segment.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/Segment.java
@@ -132,13 +132,13 @@ public class Segment extends TMCLocation {
 		return ret;
 	}
 	
-	private Segment getNegOffset() {
+	public Segment getNegOffset() {
 		if ((this.negOffset == null) && (this.negOffLcd != -1))
 			this.negOffset = TMC.getSegment(this.cid, this.tabcd, this.negOffLcd);
 		return this.negOffset;
 	}
 	
-	private Segment getPosOffset() {
+	public Segment getPosOffset() {
 		if ((this.posOffset == null) && (this.posOffLcd != -1))
 			this.posOffset = TMC.getSegment(this.cid, this.tabcd, this.posOffLcd);
 		return this.posOffset;
@@ -223,6 +223,29 @@ public class Segment extends TMCLocation {
 		if ((ret == null) && (!"".equals(this.roadNumber)))
 			ret = this.roadNumber;
 		return ret;
+	}
+
+	/**
+	 * @brief Whether this location is the direct or indirect child of another location.
+	 * 
+	 * {@code Segment} has a reference to an area, a segment and a road. If any of these is
+	 * non-null, then the instance is a child of that location (and any other location that the
+	 * parent location is a child of).
+	 * 
+	 * @param location The potential parent location.
+	 * @return True if this location is a child of {@code location}, false if not.
+	 */
+	@Override
+	public boolean isChildOf(TMCLocation location) {
+		if (location.equals(area) || location.equals(road) || location.equals(segment))
+			return true;
+		if ((area != null) && area.isChildOf(location))
+			return true;
+		if ((road != null) && road.isChildOf(location))
+			return true;
+		if ((segment != null) && segment.isChildOf(location))
+			return true;
+		return false;
 	}
 
 	@Override

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/SupplementaryInfo.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/SupplementaryInfo.java
@@ -1,8 +1,8 @@
 package eu.jacquet80.rds.app.oda.tmc;
 
 public class SupplementaryInfo {
-	public int code;
-	public String text;
+	public final int code;
+	public final String text;
 
 	SupplementaryInfo(String line) {
 		String[] comp = TMC.colonPattern.split(line);

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMC.java
@@ -212,7 +212,12 @@ public class TMC {
 	public static TMCEvent getEvent(int code) {
 		TMCEvent r = EVENTS.get(code);
 		if(r == null) {
-			r = new TMCEvent(code + ";unknown#" + code + ";;;;;;D;1;;1;A50;");
+			/* 
+			 * Event not in list. Create a new event on the fly.
+			 * Update class for undefined events is 0 (illegal in TMC) so that these events will
+			 * never update valid ones, and can easily be recognized.
+			 */
+			r = new TMCEvent(code + ";unknown#" + code + ";;;;;;D;1;;0;Y7;");
 		}
 		return r;
 	}

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCEvent.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCEvent.java
@@ -2,15 +2,15 @@ package eu.jacquet80.rds.app.oda.tmc;
 
 
 public class TMCEvent {
-	public int code;
-	public String text;
-	public String textQ;
-	public EventNature nature; // N (blank, F, S)
-	public int quantifierType; // Q
-	public EventDurationType durationType; // T duration type (D=Dynamic, L=Longer lasting)
-	public boolean bidirectional; // D directionality (1=unidirectional, 2=bidirectional)
-	public EventUrgency urgency; // U (blank, U, X)
-	public int updateClass;  // C
+	public final int code;
+	public final String text;
+	public final String textQ;
+	public final EventNature nature; // N (blank, F, S)
+	public final int quantifierType; // Q
+	public final EventDurationType durationType; // T duration type (D=Dynamic, L=Longer lasting)
+	public final boolean bidirectional; // D directionality (1=unidirectional, 2=bidirectional)
+	public final EventUrgency urgency; // U (blank, U, X)
+	public final int updateClass;  // C
 	// R phrasal code (NOT TO BE IMPLEMENTED HERE)
 	
 	public static enum EventDurationType {
@@ -138,8 +138,10 @@ public class TMCEvent {
 		String[] comp = TMC.colonPattern.split(line);
 		this.code = Integer.parseInt(comp[0]);
 		this.textQ = comp[1];
-		this.text = comp[2];
-		if(this.text.length() == 0) this.text = this.textQ;
+		if (comp[2].length() > 0)
+			this.text = comp[2];
+		else
+			this.text = this.textQ;
 		this.nature = EventNature.forCode(comp[5]);
 		
 		if("".equals(comp[6])) {

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCEvent.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCEvent.java
@@ -23,6 +23,17 @@ public class TMCEvent {
 				return DYNAMIC;
 			}
 		}
+		
+		/**
+		 * @brief Returns the inverted duration type.
+		 */
+		public EventDurationType invert() {
+			switch(this) {
+			case LONGER_LASTING: return DYNAMIC;
+			case DYNAMIC: return LONGER_LASTING;
+			default: return this;
+			}
+		}
 
 		@Override
 		public String toString() {

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCLocation.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCLocation.java
@@ -246,6 +246,25 @@ public abstract class TMCLocation {
 		return null;
 	}
 	
+	/**
+	 * @brief Whether this location is the direct or indirect child of another location.
+	 * 
+	 * The base class, {@code TMCLocation}, has a reference to an area. If it is non-null, then the
+	 * instance is a child of that area (and any other location that the area is a child of).
+	 * 
+	 * Descendants of {@code TMCLocation} can have additional parent objects.
+	 * 
+	 * @param location The potential parent location.
+	 * @return True if this location is a child of {@code location}, false if not.
+	 */
+	public boolean isChildOf(TMCLocation location) {
+		if (area == null)
+			return false;
+		if (location.equals(area))
+			return true;
+		return area.isChildOf(location);
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder res = new StringBuilder("CID: ").append(cid);

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCPoint.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCPoint.java
@@ -210,13 +210,13 @@ public class TMCPoint extends TMCLocation {
 		return ret;
 	}
 	
-	private TMCPoint getNegOffset() {
+	public TMCPoint getNegOffset() {
 		if ((this.negOffset == null) && (this.negOffLcd != -1))
 			this.negOffset = TMC.getPoint(this.cid, this.tabcd, this.negOffLcd);
 		return this.negOffset;
 	}
 	
-	private TMCPoint getPosOffset() {
+	public TMCPoint getPosOffset() {
 		if ((this.posOffset == null) && (this.posOffLcd != -1))
 			this.posOffset = TMC.getPoint(this.cid, this.tabcd, this.posOffLcd);
 		return this.posOffset;
@@ -302,6 +302,31 @@ public class TMCPoint extends TMCLocation {
 		if ((ret == null) && (this.segment != null))
 			ret = this.segment.getRoadNumber();
 		return ret;
+	}
+
+	/**
+	 * @brief Whether this location is the direct or indirect child of another location.
+	 * 
+	 * {@code TMCPoint} has a reference to an area, an other area, a segment and a road. If any of
+	 * these is non-null, then the instance is a child of that location (and any other location
+	 * that the parent location is a child of).
+	 * 
+	 * @param location The potential parent location.
+	 * @return True if this location is a child of {@code location}, false if not.
+	 */
+	@Override
+	public boolean isChildOf(TMCLocation location) {
+		if (location.equals(area) || location.equals(othArea) || location.equals(road) || location.equals(segment))
+			return true;
+		if ((area != null) && area.isChildOf(location))
+			return true;
+		if ((othArea != null) && othArea.isChildOf(location))
+			return true;
+		if ((road != null) && road.isChildOf(location))
+			return true;
+		if ((segment != null) && segment.isChildOf(location))
+			return true;
+		return false;
 	}
 
 	@Override

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCPoint.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCPoint.java
@@ -99,6 +99,8 @@ public class TMCPoint extends TMCLocation {
 		this.tcd = rset.getInt("TCD");
 		this.stcd = rset.getInt("STCD");
 		this.junctionNumber = rset.getString("JUNCTIONNUMBER");
+		if (rset.wasNull())
+			this.junctionNumber = null;
 		int rnid = rset.getInt("RNID");
 		if (!rset.wasNull()) {
 			this.rnid = rnid;

--- a/RDSSurveyor/src/eu/jacquet80/rds/core/OtherNetwork.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/core/OtherNetwork.java
@@ -34,10 +34,22 @@ import java.util.Map;
 import java.util.Set;
 
 
+/**
+ * Represents an Other Network, as transmitted in Extended Other Network (EON) information or by
+ * some ODA applications.
+ */
 public class OtherNetwork extends Station {
 	private Map<Integer, Set<Integer>> mappedAFs = Collections.synchronizedMap(new HashMap<Integer, Set<Integer>>());
 	private Set<Integer> pseudoMethodAAFs = new HashSet<Integer>();
 	
+	/**
+	 * @brief Adds a mapped frequency.
+	 * 
+	 * @param channel The tuned (current) frequency, represented as a channel number
+	 * @param mappedChannel The mapped (other) frequency, represented as a channel number
+	 * 
+	 * @return A textual representation of the mapping
+	 */
 	@Override
 	public String addMappedFreq(int channel, int mappedChannel) {
 		int freq = channelToFrequency(channel);
@@ -58,6 +70,16 @@ public class OtherNetwork extends Station {
 		return frequencyToString(freq) + " -> " + frequencyToString(mappedFreq);
 	}
 	
+	/**
+	 * @brief Adds a pair of alternate frequencies.
+	 * 
+	 * If the first frequency is a list length indicator, it will be ignored.
+	 * 
+	 * @param a The first alternate frequency, represented as a channel number
+	 * @param b The second alternate frequency, represented as a channel number
+	 * 
+	 * @return A textual representation of the two frequencies
+	 */
 	@Override
 	public synchronized String addAFPair(int a, int b) {
 		StringBuffer res = new StringBuffer("Pseudo-method A: ");
@@ -105,6 +127,14 @@ public class OtherNetwork extends Station {
 			}
 		}
 		return res;
+	}
+	
+	public Map<Integer, Set<Integer>> getMappedAFs() {
+		return mappedAFs;
+	}
+	
+	public Set<Integer> getPseudoMethodAAFs() {
+		return pseudoMethodAAFs;
 	}
 	
 	public String toString() {

--- a/RDSSurveyor/src/eu/jacquet80/rds/core/OtherNetwork.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/core/OtherNetwork.java
@@ -40,7 +40,7 @@ import java.util.Set;
  */
 public class OtherNetwork extends Station {
 	private Map<Integer, Set<Integer>> mappedAFs = Collections.synchronizedMap(new HashMap<Integer, Set<Integer>>());
-	private Set<Integer> pseudoMethodAAFs = new HashSet<Integer>();
+	private Set<Integer> pseudoMethodAAFs = Collections.synchronizedSet(new HashSet<Integer>());
 	
 	/**
 	 * @brief Adds a mapped frequency.

--- a/RDSSurveyor/src/eu/jacquet80/rds/core/Station.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/core/Station.java
@@ -78,7 +78,14 @@ public abstract class Station {
 		this.timeOfLastPI = time;
 	}
 
-	protected static int channelToFrequency(int channel) {
+	/**
+	 * @brief Converts an RDS channel code to a frequency.
+	 * 
+	 * @param channel The RDS channel (an integer in the 0–205 range, 205 being the filler code)
+	 * @return The frequency in multiples of 100 kHz, or -1 for the filler code, or 0 if an invalid
+	 * code was supplied
+	 */
+	public static int channelToFrequency(int channel) {
 		if(channel >= 0 && channel <= 204) return 875 + channel;
 		else if(channel == 205) return -1;		// -1 = filler code
 		else return 0;

--- a/RDSSurveyor/src/eu/jacquet80/rds/core/TMCOtherNetwork.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/core/TMCOtherNetwork.java
@@ -1,0 +1,100 @@
+/*
+ RDS Surveyor -- RDS decoder, analyzer and monitor tool and library.
+ For more information see
+   http://www.jacquet80.eu/
+   http://rds-surveyor.sourceforge.net/
+ 
+ Copyright (c) 2009, 2010 Christophe Jacquet
+
+ This file is part of RDS Surveyor.
+
+ RDS Surveyor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ RDS Surveyor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser Public License for more details.
+
+ You should have received a copy of the GNU Lesser Public License
+ along with RDS Surveyor.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+package eu.jacquet80.rds.core;
+
+import eu.jacquet80.rds.app.oda.AlertC;
+
+/**
+ * Encapsulates an Other Network (ON) obtained from TMC/AlertC Tuning Information.
+ * 
+ * TMC Tuning Information is equivalent to RDS EON in many ways, with a few additions. Four
+ * different variants of transmitting Other Network information are available:
+ * <ul>
+ * <li>Variant 6: Program Identification (PI) code and two Alternate Frequencies (AFs)</li>
+ * <li>Variant 7: Mapping of a Tuned Network (TN) frequency to a PI and AF</li>
+ * <li>Variant 8: Two PI codes, which carry the same TMC service on all frequencies (AFI bit set)</li>
+ * <li>Variant 9: PI code and Location Table Number (LTN), Message Geographical Scope (MGS) and
+ * Service Identifier (SID) for the TMC service carried on all frequencies of that station (AFI
+ * bit set)</li>
+ * </ul>
+ * 
+ * With the exception of Variant 9, the Other Network carries the same TMC service as the current
+ * station. Variant 9 implies that messages from the TMC service indicated may update messages
+ * received from the current service, and vice versa.
+ */
+public class TMCOtherNetwork extends OtherNetwork {
+	private int ltn = -1;
+	private int mgs = 0;
+	private int sid = -1;
+
+	public TMCOtherNetwork(int pi) {
+		super(pi);
+	}
+	
+	/**
+	 * @brief Returns the Location Table Number for this station.
+	 * 
+	 * @return The LTN, or -1 if it is the same as for the current station
+	 */
+	public int getLtn() {
+		return ltn;
+	}
+	
+	/**
+	 * @brief Returns the Message Geographical Scope for this station.
+	 * 
+	 * @return The MGS, or 0 if it is the same as for the current station
+	 */
+	public int getMgs() {
+		return mgs;
+	}
+	
+	/**
+	 * @brief Returns the Service Identifier for this station.
+	 * 
+	 * @return The SID, or -1 if it is the same as for the current station
+	 */
+	public int getSid() {
+		return sid;
+	}
+	
+	/**
+	 * @brief Sets TMC service information for this station.
+	 * 
+	 * @param ltn Location Table Number
+	 * @param mgs Message Geographical Scope
+	 * @param sid Service Identifier
+	 * 
+	 * @return A textual representation of the service information
+	 */
+	public String setService(int ltn, int mgs, int sid) {
+		this.ltn = ltn;
+		this.mgs = mgs;
+		this.sid = sid;
+		return "LTN=" + ltn + ", MGS=" + AlertC.decodeMGS(mgs) + ", SID=" + sid;
+	}
+
+}

--- a/RDSSurveyor/src/eu/jacquet80/rds/ui/app/AlertCPanel.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/ui/app/AlertCPanel.java
@@ -153,7 +153,7 @@ public class AlertCPanel extends AppPanel {
 				int row = tblList.getSelectedRow();
 				if(row >= 0) {
 					Message msg = app.getMessages().get(row);
-					latestSelectedLocation = msg.getLocation();
+					latestSelectedLocation = msg.getLcid();
 					txtDetails.setText(msg.html());
 				} else {
 					txtDetails.setText("");
@@ -244,7 +244,7 @@ public class AlertCPanel extends AppPanel {
 			case 0:
 				String ret = msg.getShortDisplayName();
 				if (ret == null)
-					ret = "#" + msg.getLocation();
+					ret = "#" + msg.getLcid();
 				return ret;
 			case 1:
 				StringBuffer buf = new StringBuffer();
@@ -266,7 +266,7 @@ public class AlertCPanel extends AppPanel {
 		private int getRowForLocation(int location) {
 			int row = 0;
 			for(AlertC.Message m : app.getMessages()) {
-				if(m.getLocation() == location) {
+				if(m.getLcid() == location) {
 					return row;
 				}
 				row++;

--- a/RDSSurveyor/src/eu/jacquet80/rds/ui/app/AlertCPanel.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/ui/app/AlertCPanel.java
@@ -153,7 +153,7 @@ public class AlertCPanel extends AppPanel {
 				int row = tblList.getSelectedRow();
 				if(row >= 0) {
 					Message msg = app.getMessages().get(row);
-					latestSelectedLocation = msg.getLcid();
+					latestSelectedLocation = msg.lcid;
 					txtDetails.setText(msg.html());
 				} else {
 					txtDetails.setText("");
@@ -244,7 +244,7 @@ public class AlertCPanel extends AppPanel {
 			case 0:
 				String ret = msg.getShortDisplayName();
 				if (ret == null)
-					ret = "#" + msg.getLcid();
+					ret = "#" + msg.lcid;
 				return ret;
 			case 1:
 				StringBuffer buf = new StringBuffer();
@@ -266,7 +266,7 @@ public class AlertCPanel extends AppPanel {
 		private int getRowForLocation(int location) {
 			int row = 0;
 			for(AlertC.Message m : app.getMessages()) {
-				if(m.getLcid() == location) {
+				if(m.lcid == location) {
 					return row;
 				}
 				row++;


### PR DESCRIPTION
This branch adds a couple of features which allow using the RDS Surveyor JAR as a backend library for TMC applications (and possibly other RDS applications):

* Most TMC message data is exposed as public members (final fields or getter methods; some previously existing getter methods were dropped in favor of public final fields)
* If LTN and SID for a message are known (because they have previously been received), they can be injected into messages
* Unknown events (with undefined event codes) are assigned a “special” update class so they don’t override other messages with valid codes
* Destination and diversion locations in information blocks can be parsed
* TMC Other Network (ON) information is stored in parseable form
* Cancellation messages can optionally be stored
* Encrypted TMC services are now detected and the correct LTN (LTNBE) is reported (decryption is not supported yet, though)
* `LocationComparator` to sort TMC locations by their order along a linear feature
* `MessageVisitor` which can be used e.g. for persistent storage of messages
* Messages are now constructed via a public `MessageBuilder`, which can be used to reconstruct messages from persistent storage
* Message duration type and nature are now stored with the message, rather than manipulating its constituent events
* Location-related members were renamed for consistency: `location` or a synonym thereof to refer to resolved locations, `lcid` or `fooLcid` for location codes
* `TMCEvent` and `SupplementaryInfo` instances are now immutable

For an example of an application which uses RDS Surveyor in this manner, look at https://gitlab.com/mvglasow/qz.