### PR TITLE
GnsGroupReader: close reader and terminate thread on IOException

### DIFF
--- a/RDSSurveyor/src/eu/jacquet80/rds/input/GnsGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/GnsGroupReader.java
@@ -483,8 +483,9 @@ public class GnsGroupReader extends TunerGroupReader implements Closeable {
 							responseStart += len;
 						}
 					} catch (IOException e) {
-						// TODO Auto-generated catch block
 						e.printStackTrace();
+						close();
+						return;
 					}
 
 					if (responseStart < 10) {


### PR DESCRIPTION
If an `IOException` is thrown while reading from a GnsGroupReader, close the reader and terminate the `ResponseReader` thread, preventing “undead” threads after an unclean disconnect of the device.

We cannot count on loss of a device to generate a notification or be reliably detectable in other ways than read operations failing. Specifically, when a Bluetooth connection is lost on Android, this does not reliably generate a broadcast (to which the application could react). This fix ensures that such threads terminate.

As a potential side effect, any `IOException` will terminate the thread, even if were to be caused by a temporary condition, and the user (or caller) would need to restart the reader once the condition is fixed. So far, I have not encountered a case where this would be an issue.