### PR TITLE
SdrGroupReader: Fix faulty merge #aeebad4

### DIFF
--- a/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
@@ -4,11 +4,17 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.DataLine;
+import javax.sound.sampled.SourceDataLine;
 
 import eu.jacquet80.rds.core.BitStreamSynchronizer;
 import eu.jacquet80.rds.core.BitStreamSynchronizer.Status;
@@ -18,11 +24,19 @@ import eu.jacquet80.rds.log.RealTime;
 
 public class SdrGroupReader extends TunerGroupReader {
 	/** The sample rate at which we receive data from the tuner. */
-	private static final int sampleRate = 250000;
+	private static final int sampleRate = 128000;
 	
+	/** The sample rate for audio output. */
+	private static final int outSampleRate = 48000;
+	
+	/* The stream from which demodulated audio data is read, linked to tunerOut */
 	private final PipedInputStream syncIn;
+	/* The stream to which the native plugin writes demodulated audio data. */
 	private final DataOutputStream tunerOut;
+	/* The audio bit reader which handles audio stream decoding and provides an audio input stream */
+	private final AudioBitReader reader;
 	private final BitStreamSynchronizer synchronizer;
+	private final InputStream audioStream;
 	private boolean synced = false;
 	private boolean newGroups;
 	
@@ -36,11 +50,16 @@ public class SdrGroupReader extends TunerGroupReader {
 	/* Received signal strength in dBm. Always use getter method for this. */
 	private Float mRssi = new Float(0);
 	
-	// TODO check which members we need
 	private static final String dir, sep;
 	private boolean audioCapable = false;
 	private boolean audioPlaying = false;
+	
+	/* Whether audio was suspended (e.g. for a seek operation) and should resume once the operation
+	 * is complete */
+	private boolean wasPlaying = false;
+	
 	private final Semaphore resumePlaying = new Semaphore(0);
+
 
 	public SdrGroupReader(PrintStream console, String filename) throws UnavailableInputMethod, IOException {
 		File path = new File(filename);
@@ -56,7 +75,10 @@ public class SdrGroupReader extends TunerGroupReader {
 
 		syncIn = new PipedInputStream();
 		tunerOut = new DataOutputStream(new PipedOutputStream(syncIn));
-		synchronizer = new BitStreamSynchronizer(console, new AudioBitReader(new DataInputStream(syncIn), sampleRate));
+		reader = new AudioBitReader(new DataInputStream(syncIn), sampleRate);
+		reader.setAudioSampleRate(outSampleRate);
+		audioStream = reader.getAudioMirrorStream();
+		synchronizer = new BitStreamSynchronizer(console, reader);
 		
 		synchronizer.addStatusChangeListener(new BitStreamSynchronizer.StatusChangeListener() {
 			@Override
@@ -74,17 +96,15 @@ public class SdrGroupReader extends TunerGroupReader {
 					aFilename + ": no device found");
 		}
 		
-		/* TODO implement sound
 		SoundPlayer p = new SoundPlayer();
 		if(audioCapable) {
 			p.start();
 		}
-		*/
 	}
 
 	@Override
 	public boolean isStereo() {
-		return false; // TODO implement sound
+		return false; // TODO implement stereo
 		//return data.stereo;
 	}
 
@@ -139,38 +159,37 @@ public class SdrGroupReader extends TunerGroupReader {
 
 	@Override
 	public boolean isAudioCapable() {
-		return false; // TODO implement sound
-		// return audioCapable;
+		return audioCapable;
 	}
 
 	@Override
 	public boolean isPlayingAudio() {
-		return false; // TODO implement sound
-		// return audioPlaying;
+		return audioPlaying;
 	}
 	
 	/**
 	 * @brief Returns the signal strength of the current station.
 	 * 
 	 * Signal strength is expressed as a value between 0 and 65535, which corresponds to a range
-	 * from -30 dBm to +10 dBm. These values were chosen because the noise level is slightly above
-	 * -30 dBm, whereas strong nearby transmitters with a minimum of block errors reach +10 dBm and
-	 * more. It also places -10 dBm, which is the practical limit for RDS reception, in the middle
-	 * of the range.
+	 * from -30 dBm to +45 dBm. This mapping was modeled after the Si470x driver, which obtains
+	 * RSSI by reading from the chip's 0x0a register, which provides a 8-bit value (0-255). This is
+	 * then multiplied by 873 (which would allow for a 0-75 input range without causing an
+	 * overflow). Silicon Labs documentation (AN230) anecdotally indicates a practical range of 0
+	 * to +45 dB, which is roughly congruent with the values reported by the RTL2832U.
 	 * 
 	 * If the actual signal strength is outside the boundaries, the nearest boundary is returned.
 	 * 
 	 * The return value of this function can be calculated from signal strength as follows:
-	 * signal = (rssi + 30) * 8192 / 5
+	 * signal = rssi * 873
 	 * 
 	 * Vice versa:
-	 * rssi = signal * 5 / 8192 - 30;
+	 * rssi = signal / 873;
 	 * 
 	 * @return Signal strength
 	 */
 	@Override
 	public int getSignalStrength() {
-		int signal = (int)((getRssi() + 30) * 8192 / 5);  // 8192 / 5 = 65536 / 40
+		int signal = (int)((getRssi()) * 873);
 		if (signal < 0)
 			signal = 0;
 		else if (signal > 0xFFFF)
@@ -189,8 +208,24 @@ public class SdrGroupReader extends TunerGroupReader {
 		setFrequency(freq);
 	}
 
+	/**
+	 * @brief Seek to the next good station in the specified direction.
+	 * 
+	 * This method returns immediately, the actual seek operation typically has not completed by
+	 * that time.
+	 * 
+	 * @param up If {@code true}, seek up, else, seek down.
+	 * 
+	 * @return Always false
+	 */
 	@Override
-	public native boolean seek(boolean up);
+	public boolean seek(boolean up) {
+		wasPlaying = audioPlaying;
+		
+		if (wasPlaying)
+			mute();
+		return nativeSeek(up);
+	}
 
 	@Override
 	public native String getDeviceName();
@@ -259,6 +294,18 @@ public class SdrGroupReader extends TunerGroupReader {
 	}
 	
 	/**
+	 * @brief JNI wrapper for the native call which performs the actual seek operation.
+	 * 
+	 * This method is called by {@link #seek(boolean)}. No other code should ever need to call this
+	 * method directly.
+	 * 
+	 * @param up If {@code true}, seek up, else, seek down.
+	 * 
+	 * @return Always false
+	 */
+	private native boolean nativeSeek(boolean up);
+
+	/**
 	 * @brief Called when the tuner frequency has been changed successfully
 	 * 
 	 * This method notifies the {@code SdrGroupReader} about a successful frequency change.
@@ -274,6 +321,8 @@ public class SdrGroupReader extends TunerGroupReader {
 			this.mFrequencyChanged = true;
 		} finally {
 			frequencyLock.writeLock().unlock();
+			if (wasPlaying)
+				unmute();
 		}
 	}
 	
@@ -302,8 +351,7 @@ public class SdrGroupReader extends TunerGroupReader {
 	 * Other implementations use it to retrieve RDS data, stereo flags, and RSSI from the tuner,
 	 * requiring it to be called before the respective methods. This makes sense for a tuner but
 	 * not for a SDR: RSSI is retrieved through an event handler method, stereo is currently not
-	 * relevant due to lack of audio support (TODO) and RDS data is decoded from the audio stream
-	 * returned by the SDR.
+	 * supported (TODO) and RDS data is decoded from the audio stream returned by the SDR.
 	 *  
 	 * @return 0
 	 */
@@ -319,95 +367,57 @@ public class SdrGroupReader extends TunerGroupReader {
 	}
 
 
-	/* TODO implement sound
-	private final static String[] okVendors = { // TODO fix these
-		"SILICON",
-		"www.rding.cn"
-	};
-	
-	private final static String[] okNames = { // TODO fix these
-		"FM Radio",
-		"Radio"
-	};
-
-	
 	private class SoundPlayer extends Thread {
-		private Mixer mixer = null;
-		private TargetDataLine inLine;
 		private SourceDataLine outLine;
 
 		public SoundPlayer() {
-			
-			for(Mixer.Info mixInfo : AudioSystem.getMixerInfo()) {
-				String vendor = mixInfo.getVendor();
-				if(vendor != null) vendor = vendor.split(" ")[0];
-				
-				String name = mixInfo.getName();
-				if(name != null) name = name.split(" ")[0];
-				
-				if(Arrays.asList(okVendors).contains(vendor) ||
-						Arrays.asList(okNames).contains(name)) {
-
-					System.out.println("Trying to use audio device: '" + mixInfo.getVendor() + 
-							"', '" + mixInfo.getName() + "'");
-					
-					mixer = AudioSystem.getMixer(mixInfo);
-					if(mixer != null) break;
-				}
-			}
-			
-			if(mixer == null) {
-				System.out.println("Native tuner: not found audio device.");
-				return;
-			}
-			
 			try {
-				Line.Info[] linesInfo = mixer.getTargetLineInfo();
-				inLine = (TargetDataLine) mixer.getLine(linesInfo[0]);
-				AudioFormat inFormat =  
-						new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, 96000, 8, 1, 1, 96000, false);
-				inLine.open(inFormat);
-
 				AudioFormat outFormat =  
-						new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, 48000, 16, 1, 2, 48000, false);
-				DataLine.Info outInfo = new DataLine.Info(SourceDataLine.class, outFormat, 4*48000);
+						new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, outSampleRate, 16, 1, 2, outSampleRate, false);
+				DataLine.Info outInfo = new DataLine.Info(SourceDataLine.class, outFormat, 4 * outSampleRate);
 				outLine = (SourceDataLine) AudioSystem.getLine(outInfo);
 				outLine.open(outFormat);
 			} catch(Exception e) {
-				System.out.println("Native tuner: audio device, but could not open lines:");
+				System.out.println("SDR: could not open output line:");
 				System.out.println("\t" + e);
 				return;
 			}
 			
-			System.out.println("Both USB stick audio and sound card audio configured successfully");
-		
+			if (sampleRate < outSampleRate) {
+				System.out.println(String.format("SDR: sample rate must be %d or higher", outSampleRate));
+				return;
+			}
+			
 			audioCapable = true;
-			audioPlaying = true;
+			audioPlaying = false;
+			wasPlaying = true;
 		}
 		
 		@Override
 		public void run() {
-			byte[] data = new byte[24000];
+			byte[] inData = new byte[sampleRate / 2];
 			
-			inLine.start();
 			outLine.start();
+			reader.startPlaying();
 			
 			// simple audio pass through
 			while(true) {
-				inLine.read(data, 0, data.length);
-				outLine.write(data, 0, data.length);
+				try {
+					int len = audioStream.read(inData, 0, inData.length);
+					outLine.write(inData, 0, len);
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
 				
 				if(! audioPlaying) {
-					inLine.stop();
+					reader.stopPlaying();
 					outLine.stop();
-					inLine.flush();
 					outLine.flush();
 					resumePlaying.acquireUninterruptibly();
-					inLine.start();
 					outLine.start();
+					reader.startPlaying();
 				}
 			}
 		}
 	}
-	*/
 }


### PR DESCRIPTION
Restores a bunch of things in `SdrGroupReader`, which were lost in a faulty merge (aeebad408):

* Audio
* Improved RSSI scale (modeled after Si470x driver)
* Lower sample rate to reduce CPU load

This reverts the merge of the stale `SdrGroupReader`, with the actual changes of the branch re-added manually.