### PR TITLE
Fix several NPEs in TMC parsing routines

### DIFF
--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -1366,7 +1366,7 @@ public class AlertC extends ODA {
 				return null;
 			if (!(secondary instanceof TMCPoint))
 				return null;
-			if ((secondary.name1.name == null) || (secondary.name1.name.isEmpty()))
+			if ((secondary.name1 == null) || (secondary.name1.name == null) || (secondary.name1.name.isEmpty()))
 				return null;
 			else
 				return secondary.name1.name;

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/AlertC.java
@@ -1311,7 +1311,7 @@ public class AlertC extends ODA {
 				return null;
 			if (!(location instanceof TMCPoint))
 				return null;
-			if ((location.name1.name == null) || (location.name1.name.isEmpty()))
+			if ((location.name1 == null) || (location.name1.name == null) || (location.name1.name.isEmpty()))
 				return null;
 			else
 				return location.name1.name;

--- a/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCPoint.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/app/oda/tmc/TMCPoint.java
@@ -288,7 +288,7 @@ public class TMCPoint extends TMCLocation {
 			else
 				return name1.name;
 		else
-			if (junctionNumber.isEmpty())
+			if ((junctionNumber == null) || junctionNumber.isEmpty())
 				return null;
 			else
 				return junctionNumber;


### PR DESCRIPTION
Simple fixes for several NPEs which may cause incomplete TMC message lists, or crashes when using RDS Surveyor as a library