### PR TITLE
Fix GUI deadlock upon station change

### DIFF
--- a/RDSSurveyor/src/eu/jacquet80/rds/RDSSurveyor.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/RDSSurveyor.java
@@ -384,7 +384,7 @@ public class RDSSurveyor {
 		if(scan) {
 			if(reader instanceof TunerGroupReader) {
 				final TunerGroupReader tgr = (TunerGroupReader) reader;
-				new Thread() {
+				new Thread("Scanner") {
 					public void run() {
 						while(true) {
 							int cnt = 0;

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/AudioBitReader.java
@@ -136,7 +136,7 @@ public class AudioBitReader extends BitReader {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-		new Thread() {
+		new Thread("AudioBitReader") {
 			public void run() {
 				/* Subcarrier frequency */
 				double fsc = FC_0;

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/GnsGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/GnsGroupReader.java
@@ -455,6 +455,10 @@ public class GnsGroupReader extends TunerGroupReader implements Closeable {
 	 * appropriate data structures.
 	 */
 	private class ResponseReader extends Thread {
+		{
+			setName("GnsGroupReader#ResponseReader");
+		}
+
 		@Override
 		public void run() {
 			while (!closed) {

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/LiveAudioBitReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/LiveAudioBitReader.java
@@ -105,7 +105,7 @@ public class LiveAudioBitReader extends BitReader {
 		
 		line.start();
 
-		new Thread() {
+		new Thread("LiveAudioBitReader") {
 			public void run() {
 				for(;;) {
 					line.read(receiveFrame, 0, 2 * frameLength);

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/NativeTunerGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/NativeTunerGroupReader.java
@@ -198,6 +198,10 @@ public class NativeTunerGroupReader extends TunerGroupReader {
 
 	
 	private class SoundPlayer extends Thread {
+		{
+			setName("NativeTunerGroupReader#SoundPlayer");
+		}
+
 		private Mixer mixer = null;
 		private TargetDataLine inLine;
 		private SourceDataLine outLine;

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/SdrGroupReader.java
@@ -370,6 +370,10 @@ public class SdrGroupReader extends TunerGroupReader {
 
 
 	private class SoundPlayer extends Thread {
+		{
+			setName("SdrGoupReader#SoundPlayer");
+		}
+
 		private SourceDataLine outLine;
 
 		public SoundPlayer() {

--- a/RDSSurveyor/src/eu/jacquet80/rds/tests/TestV4L.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/tests/TestV4L.java
@@ -53,7 +53,7 @@ public class TestV4L {
 		decoder = new GroupLevelDecoder(log);
 		radio = new V4LTunerGroupReader("/dev/radio0");
 
-		new Thread() {
+		new Thread("TestV4L") {
 			public void run() {
 				while(true) {
 					try {

--- a/RDSSurveyor/src/eu/jacquet80/rds/ui/InputSelectionDialog.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/ui/InputSelectionDialog.java
@@ -142,7 +142,7 @@ public class InputSelectionDialog extends JFrame implements ActionListener {
 					RDSSurveyor.preferences.put(RDSSurveyor.PREF_LAST_DIR, fc.getSelectedFile().getParent());
 				}
 			} else if(source == btnTCP) {
-				Thread t = new Thread() {
+				Thread t = new Thread("NetworkOpenDialog") {
 					public void run() {
 						choice = NetworkOpenDialog.dialog();
 						choiceDone.release();

--- a/RDSSurveyor/src/eu/jacquet80/rds/ui/MainWindow.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/ui/MainWindow.java
@@ -399,19 +399,18 @@ public class MainWindow extends JFrame {
 			
 			@Override
 			public void visit(StationTuned stationTuned) {
-				synchronized(MainWindow.this) {
-					bler.clear();
-					latestGroups.clear();
-					station = stationTuned.getStation();
-					eonTableModel.setTunedStation(station);
-					pnlRT.setStation(station);
-					pnlODA.setStation(station);
-				}
-					
 				// reset the tabs displayed
 				try {
 					SwingUtilities.invokeAndWait(new Runnable() {
 						public void run() {
+							synchronized(MainWindow.this) {
+								bler.clear();
+								latestGroups.clear();
+								station = stationTuned.getStation();
+								eonTableModel.setTunedStation(station);
+								pnlRT.setStation(station);
+								pnlODA.setStation(station);
+							}
 							tabbedPane.removeAll();
 							tabbedPane.addTab("Base", pnlAF);
 							tabbedPane.addTab("EON", pnlEON);

--- a/RDSSurveyor/src/eu/jacquet80/rds/ui/Menu.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/ui/Menu.java
@@ -77,7 +77,7 @@ public class Menu {
 				final JMenuItem item = (JMenuItem) e.getSource();
 				
 				// the actions cannot be performed in AWT's dispatch thread
-				new Thread() {
+				new Thread("Menu-ActionListener") {
 					public void run() {
 						JFrame window = null;
 						

--- a/RDSSurveyor/src/eu/jacquet80/rds/ui/Overviewer.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/ui/Overviewer.java
@@ -16,6 +16,7 @@ public class Overviewer extends Thread {
 	public Overviewer(TunerGroupReader tgr, PrintStream console) {
 		this.tgr = tgr;
 		this.console = console;
+		this.setName("Overviewer");
 	}
 	
 	public void run() {

--- a/RDSSurveyor/src/eu/jacquet80/rds/ui/input/LiveAudioToolBar.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/ui/input/LiveAudioToolBar.java
@@ -30,7 +30,7 @@ public class LiveAudioToolBar extends InputToolBar {
 		lblStatus.setPreferredSize(new Dimension(100, 30));
 		add(lblStatus);
 		
-		new Thread() {
+		new Thread("LiveAudioToolBar") {
 			public void run() {
 				while(active) {
 					// update label

--- a/RDSSurveyor/src/eu/jacquet80/rds/ui/input/TunerToolBar.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/ui/input/TunerToolBar.java
@@ -167,7 +167,7 @@ public class TunerToolBar extends InputToolBar {
 		
 		update();
 		
-		new Thread() {
+		new Thread("TunerToolBar") {
 			public void run() {
 				while(active) {
 					update();


### PR DESCRIPTION
See #41—this fixes the deadlock by moving GUI updates related to station changes off the RDS worker thread into the AWT event queue thread, which also handles periodic updates. According to a brief test, this seems to fix the issue.

Additionally, this PR ensures each thread created by RDS Surveyor directly is assigned a name, to ease future debugging.