### PR TITLE
GnsGroupReader: fix RSSI conversion

### DIFF
--- a/RDSSurveyor/src/eu/jacquet80/rds/input/GnsGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/GnsGroupReader.java
@@ -595,7 +595,7 @@ public class GnsGroupReader extends TunerGroupReader implements Closeable {
 								 * TODO not sure if conversion is correct
 								 * (maximum is 0xFF in theory, presumably 0x3F or more, up to 0x2C observed so far)
 								 */
-								gnsData.rssi = intData[6] * 0x410;
+								gnsData.rssi = intData[6] * 0xFFFF / 0x3F;
 							}
 						}
 						opcodes.remove(Integer.valueOf(intData[3]));

--- a/RDSSurveyor/src/eu/jacquet80/rds/input/GnsGroupReader.java
+++ b/RDSSurveyor/src/eu/jacquet80/rds/input/GnsGroupReader.java
@@ -593,9 +593,9 @@ public class GnsGroupReader extends TunerGroupReader implements Closeable {
 								}
 								/*
 								 * TODO not sure if conversion is correct
-								 * (maximum is 0xFF in theory, 0x1F is maximum observed so far)
+								 * (maximum is 0xFF in theory, presumably 0x3F or more, up to 0x2C observed so far)
 								 */
-								gnsData.rssi = intData[6] * 0x842;
+								gnsData.rssi = intData[6] * 0x410;
 							}
 						}
 						opcodes.remove(Integer.valueOf(intData[3]));


### PR DESCRIPTION
Maximum observed so far is 0x2C (see #37), thus the upper limit is (probably) at least 0x3F